### PR TITLE
新增 MIT 授權與 README；加入 Deploy/Research 任務與 HUD/UX 調整

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gary-GaGa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -225,11 +225,32 @@ go build -o bin/ebiten-client ./client/cmd/ebiten-client
 ### 操作鍵（Controls）
 
 - P：開始練習任務（Practice）
-- F：嘗試完成（Try Finish）
+- T：開始 Targeted 任務（短時、略高獎勵）
 - U：升級 Knowledge（消耗 Research；不足時會提示）
 - C：結算離線收益（Claim Offline）
 - 1/2/3：切換語言（Go / Python / JavaScript）
 
-提示：左側 Status 卡會顯示 Est. Success（估計成功率）、Rates（每分鐘知識/研發產率）。任務卡會顯示語言、Base 奖勵與總時長，右側圓環以 mm:ss 倒數。
+任務行為：
+
+- 當沒有進行中任務時，會自動開始練習（Practice）。
+- 任務倒數至 0 後，會自動嘗試結算（Try Finish），不用手動按鍵。
+
+提示：
+
+- 左側 Status 卡會顯示 Est. Success（估計成功率）、Rates（每分鐘知識/研發產率）。
+- 中央任務卡會顯示語言、Base 奬勵與總時長，右側圓環以 mm:ss 倒數。
+- 中央任務卡背景有淡藍藍圖格線與任務型別標籤（Practice/Targeted）。
+- 右側 Languages 面板每列提供升級進度條（Research / Next Cost），並在可升級時顯示 READY 徽章；當前選中的語言以強調色顯示。
 
 如遇連線狀態，左側會短暫顯示 Networking...，錯誤則以 Error 行顯示；升級不足會有 toast 提示。
+
+---
+
+## License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details.
+
+## Disclaimer
+
+Some game mechanics or ideas are inspired by existing idle/incremental games.  
+This project is non-commercial and created for educational purposes only.  

--- a/app/adapter/in/httpserver/game/handler.go
+++ b/app/adapter/in/httpserver/game/handler.go
@@ -66,6 +66,36 @@ func (h *Handler) PostStartPractice(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
 }
 
+// Start a targeted task immediately (slightly higher reward / shorter duration)
+func (h *Handler) PostStartTargeted(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	if err := h.uc.StartTargeted(now); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
+}
+
+// Start a deploy task immediately
+func (h *Handler) PostStartDeploy(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	if err := h.uc.StartDeploy(now); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
+}
+
+// Start a research task immediately
+func (h *Handler) PostStartResearch(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	if err := h.uc.StartResearch(now); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
+}
+
 // Try to finish current task
 type finishResp struct {
 	Finished  bool             `json:"finished"`
@@ -102,6 +132,31 @@ func (h *Handler) PostSelectLanguage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
+}
+
+// Buy a server (consumes Knowledge; adds GPU slots)
+type buyResp struct {
+	OK        bool             `json:"ok"`
+	ViewModel dto.ViewModelDto `json:"viewModel"`
+}
+
+func (h *Handler) PostBuyServer(w http.ResponseWriter, r *http.Request) {
+	ok, err := h.uc.BuyServer()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, buyResp{OK: ok, ViewModel: h.uc.GetViewModel()})
+}
+
+// Buy a GPU (consumes Knowledge; requires free slot)
+func (h *Handler) PostBuyGPU(w http.ResponseWriter, r *http.Request) {
+	ok, err := h.uc.BuyGPU()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, buyResp{OK: ok, ViewModel: h.uc.GetViewModel()})
 }
 
 // --- shared helpers (local to game module) ---

--- a/app/adapter/in/httpserver/game/router.go
+++ b/app/adapter/in/httpserver/game/router.go
@@ -13,17 +13,27 @@ func NewRouter(h *Handler) *Router {
 	mux.HandleFunc("/api/v1/game/viewmodel", h.GetViewModel)
 	mux.HandleFunc("/api/v1/game/claim-offline", h.PostClaimOffline)
 	mux.HandleFunc("/api/v1/game/start-practice", h.PostStartPractice)
+	mux.HandleFunc("/api/v1/game/start-targeted", h.PostStartTargeted)
+	mux.HandleFunc("/api/v1/game/start-deploy", h.PostStartDeploy)
+	mux.HandleFunc("/api/v1/game/start-research", h.PostStartResearch)
 	mux.HandleFunc("/api/v1/game/try-finish", h.PostTryFinish)
 	mux.HandleFunc("/api/v1/game/upgrade-knowledge", h.PostUpgradeKnowledge)
 	mux.HandleFunc("/api/v1/game/select-language", h.PostSelectLanguage)
+	mux.HandleFunc("/api/v1/game/buy-server", h.PostBuyServer)
+	mux.HandleFunc("/api/v1/game/buy-gpu", h.PostBuyGPU)
 
 	// legacy
 	mux.HandleFunc("/api/game/viewmodel", h.GetViewModel)
 	mux.HandleFunc("/api/game/claim-offline", h.PostClaimOffline)
 	mux.HandleFunc("/api/game/start-practice", h.PostStartPractice)
+	mux.HandleFunc("/api/game/start-targeted", h.PostStartTargeted)
+	mux.HandleFunc("/api/game/start-deploy", h.PostStartDeploy)
+	mux.HandleFunc("/api/game/start-research", h.PostStartResearch)
 	mux.HandleFunc("/api/game/try-finish", h.PostTryFinish)
 	mux.HandleFunc("/api/game/upgrade-knowledge", h.PostUpgradeKnowledge)
 	mux.HandleFunc("/api/game/select-language", h.PostSelectLanguage)
+	mux.HandleFunc("/api/game/buy-server", h.PostBuyServer)
+	mux.HandleFunc("/api/game/buy-gpu", h.PostBuyGPU)
 	return &Router{mux: mux}
 }
 

--- a/app/domain/task/task.go
+++ b/app/domain/task/task.go
@@ -6,6 +6,9 @@ type Type string
 
 const (
 	Practice Type = "Practice"
+	Targeted Type = "Targeted"
+	Deploy   Type = "Deploy"
+	Research Type = "Research"
 )
 
 type Task struct {

--- a/app/usecase/dto/game/viewmodel.go
+++ b/app/usecase/dto/game/viewmodel.go
@@ -17,6 +17,11 @@ type ViewModelDto struct {
 	Languages map[string]LanguageStats
 	// 任務成功率預估（0~1），以目前語言計算
 	EstimatedSuccess float64
+
+	// --- Store / Hardware ---
+	Servers int
+	GPUs    int
+	Slots   int // total slots = Servers * SlotsPerServer
 }
 
 type TaskInfo struct {

--- a/app/usecase/game/interactor.go
+++ b/app/usecase/game/interactor.go
@@ -101,12 +101,34 @@ func (uc *Interactor) GetViewModel() dto.ViewModelDto {
 			vm.Languages[k] = dto.LanguageStats{Knowledge: s.Knowledge, Research: s.Research, Level: s.Level}
 		}
 	}
+	// 商店/硬體資訊
+	vm.Servers = uc.p.Servers
+	vm.GPUs = uc.p.GPUs
+	vm.Slots = uc.p.Servers * player.SlotsPerServer
 	return vm
 }
 
 // StartPractice 啟動練習任務
 func (uc *Interactor) StartPractice(now time.Time) error {
 	uc.p.StartPractice(now)
+	return uc.repo.Save(uc.p, uc.ts)
+}
+
+// StartTargeted 啟動目標任務
+func (uc *Interactor) StartTargeted(now time.Time) error {
+	uc.p.StartTargeted(now)
+	return uc.repo.Save(uc.p, uc.ts)
+}
+
+// StartDeploy 啟動部署任務
+func (uc *Interactor) StartDeploy(now time.Time) error {
+	uc.p.StartDeploy(now)
+	return uc.repo.Save(uc.p, uc.ts)
+}
+
+// StartResearch 啟動研究任務
+func (uc *Interactor) StartResearch(now time.Time) error {
+	uc.p.StartResearch(now)
 	return uc.repo.Save(uc.p, uc.ts)
 }
 
@@ -135,4 +157,28 @@ func (uc *Interactor) UpgradeKnowledge() (ok bool, err error) {
 func (uc *Interactor) SelectLanguage(lang string) error {
 	uc.p.SelectLanguage(lang)
 	return uc.repo.Save(uc.p, uc.ts)
+}
+
+// BuyServer 購買伺服器主機（佔用 Knowledge，提供顯卡插槽）
+func (uc *Interactor) BuyServer() (bool, error) {
+	ok := uc.p.BuyServer()
+	if !ok {
+		return false, nil
+	}
+	if err := uc.repo.Save(uc.p, uc.ts); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// BuyGPU 購買顯卡（需有插槽，佔用 Knowledge，提升研究產率）
+func (uc *Interactor) BuyGPU() (bool, error) {
+	ok := uc.p.BuyGPU()
+	if !ok {
+		return false, nil
+	}
+	if err := uc.repo.Save(uc.p, uc.ts); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/app/usecase/port/in/game/game.go
+++ b/app/usecase/port/in/game/game.go
@@ -13,7 +13,12 @@ type Usecase interface {
 	ClaimOffline(now time.Time) (gametime.OfflineResult, error)
 	GetViewModel() dto.ViewModelDto
 	StartPractice(now time.Time) error
+	StartTargeted(now time.Time) error
+	StartDeploy(now time.Time) error
+	StartResearch(now time.Time) error
 	TryFinish(now time.Time) (finished bool, reward int64, err error)
 	UpgradeKnowledge() (ok bool, err error)
 	SelectLanguage(lang string) error
+	BuyServer() (bool, error)
+	BuyGPU() (bool, error)
 }

--- a/client/internal/api/gameclient/client.go
+++ b/client/internal/api/gameclient/client.go
@@ -75,6 +75,57 @@ func (c *Client) PostStartPractice(ctx context.Context) (ViewModel, error) {
 	return vm, nil
 }
 
+func (c *Client) PostStartTargeted(ctx context.Context) (ViewModel, error) {
+	var vm ViewModel
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v1/game/start-targeted", nil)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return vm, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return vm, decodeAPIError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&vm); err != nil {
+		return vm, err
+	}
+	return vm, nil
+}
+
+func (c *Client) PostStartDeploy(ctx context.Context) (ViewModel, error) {
+	var vm ViewModel
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v1/game/start-deploy", nil)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return vm, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return vm, decodeAPIError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&vm); err != nil {
+		return vm, err
+	}
+	return vm, nil
+}
+
+func (c *Client) PostStartResearch(ctx context.Context) (ViewModel, error) {
+	var vm ViewModel
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v1/game/start-research", nil)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return vm, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return vm, decodeAPIError(resp)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&vm); err != nil {
+		return vm, err
+	}
+	return vm, nil
+}
+
 func (c *Client) PostTryFinish(ctx context.Context) (FinishResponse, error) {
 	var out FinishResponse
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v1/game/try-finish", nil)
@@ -126,6 +177,46 @@ func (c *Client) PostSelectLanguage(ctx context.Context, lang string) (ViewModel
 		return vm, err
 	}
 	return vm, nil
+}
+
+func (c *Client) PostBuyServer(ctx context.Context) (ViewModel, error) {
+	var vm ViewModel
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v1/game/buy-server", nil)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return vm, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return vm, decodeAPIError(resp)
+	}
+	var out struct {
+		ViewModel ViewModel `json:"viewModel"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return vm, err
+	}
+	return out.ViewModel, nil
+}
+
+func (c *Client) PostBuyGPU(ctx context.Context) (ViewModel, error) {
+	var vm ViewModel
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/api/v1/game/buy-gpu", nil)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return vm, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return vm, decodeAPIError(resp)
+	}
+	var out struct {
+		ViewModel ViewModel `json:"viewModel"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return vm, err
+	}
+	return out.ViewModel, nil
 }
 
 func decodeAPIError(resp *http.Response) error {

--- a/client/internal/api/gameclient/types.go
+++ b/client/internal/api/gameclient/types.go
@@ -15,6 +15,10 @@ type ViewModel struct {
 	CurrentLanguage  string            `json:"CurrentLanguage"`
 	Languages        map[string]LangVM `json:"Languages"`
 	EstimatedSuccess float64           `json:"EstimatedSuccess"`
+	// Store
+	Servers int `json:"Servers"`
+	GPUs    int `json:"GPUs"`
+	Slots   int `json:"Slots"`
 }
 
 type Task struct {

--- a/client/internal/game/task/deploy.go
+++ b/client/internal/game/task/deploy.go
@@ -1,0 +1,116 @@
+package task
+
+import (
+	"math"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// deployRenderer：Worker Pool 視覺（無狀態、依時間與進度動態）。
+type deployRenderer struct {
+	totalSec     int64
+	remainingSec int64
+	rewardK      int64
+}
+
+func NewDeployRenderer() Renderer { return &deployRenderer{} }
+
+func (r *deployRenderer) Sync(totalSec, remainingSec int64, rewardK int64) {
+	r.totalSec = totalSec
+	r.remainingSec = remainingSec
+	r.rewardK = rewardK
+}
+func (r *deployRenderer) Update(dtMs time.Duration) {}
+
+func (r *deployRenderer) Draw(dst *ebiten.Image, x, y, w, h int, theme Theme) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	pad := 10
+	// 進度（0..1）
+	pct := float32(0)
+	if r.totalSec > 0 {
+		done := r.totalSec - r.remainingSec
+		if done < 0 {
+			done = 0
+		}
+		if done > r.totalSec {
+			done = r.totalSec
+		}
+		pct = float32(done) / float32(r.totalSec)
+	}
+
+	// 左：佇列槽
+	qx := x + pad
+	qy := y + pad
+	qw := 18
+	qh := h - 2*pad
+	vector.StrokeRect(dst, float32(qx), float32(qy), float32(qw), float32(qh), 1, theme.Grid, true)
+	// 佇列方塊數量隨 (1-pct)
+	qn := int(3 + 9*(1-pct))
+	if qn < 0 {
+		qn = 0
+	}
+	gap := 4
+	box := 6
+	for i := 0; i < qn; i++ {
+		by := float32(qy + 2 + i*(box+gap))
+		if int(by)+box > qy+qh-2 {
+			break
+		}
+		vector.DrawFilledRect(dst, float32(qx+3), by, float32(qw-6), float32(box), theme.Text, true)
+	}
+
+	// 中：Worker Pool 區
+	wx := x + pad + qw + 6
+	wy := y + pad
+	ww := w - 2*pad - qw - 6 - qw
+	wh := h - 2*pad
+	if ww < 40 {
+		ww = 40
+	}
+	vector.StrokeRect(dst, float32(wx), float32(wy), float32(ww), float32(wh), 1, theme.Grid, true)
+
+	// worker 欄數（寬度決定）
+	cols := int(math.Max(3, math.Min(6, float64(ww/90))))
+	colW := ww / cols
+	now := time.Now()
+	baseT := float32((now.UnixNano() % 1_000_000_000)) / 1_000_000_000
+	for c := 0; c < cols; c++ {
+		// 每欄一個 worker 進度條
+		cx := wx + c*colW
+		// 欄框
+		vector.StrokeRect(dst, float32(cx+4), float32(wy+4), float32(colW-8), float32(wh-8), 1, theme.Grid, true)
+		// 進度（加入位移讓不同欄不同步）
+		phase := float32(c) * 0.17
+		prog := float32(math.Mod(float64(baseT+phase), 1.0))
+		// 讓整體不小於任務實際進度（視覺上逐步接近完成）
+		if prog < pct*0.85 {
+			prog = pct * 0.85
+		}
+		bw := int(float32(colW-16) * prog)
+		if bw < 0 {
+			bw = 0
+		}
+		vector.DrawFilledRect(dst, float32(cx+8), float32(wy+8), float32(bw), 10, theme.Good, true)
+		// 工作列下方流動小方塊（假裝任務輸入/輸出）
+		dots := 3
+		for i := 0; i < dots; i++ {
+			dx := float32(cx + 8 + ((i*18)+int(baseT*float32(colW-24)))%(colW-24))
+			dy := float32(wy + 24)
+			vector.DrawFilledRect(dst, dx, dy, 6, 4, theme.Accent, true)
+		}
+	}
+
+	// 右：完成槽，堆高隨進度
+	fx := x + w - pad - qw
+	fy := y + pad
+	fh := h - 2*pad
+	vector.StrokeRect(dst, float32(fx), float32(fy), float32(qw), float32(fh), 1, theme.Grid, true)
+	fillH := int(float32(fh-4) * pct)
+	if fillH > 0 {
+		vector.DrawFilledRect(dst, float32(fx+2), float32(fy+fh-2-fillH), float32(qw-4), float32(fillH), theme.Good, true)
+	}
+}

--- a/client/internal/game/task/hud.go
+++ b/client/internal/game/task/hud.go
@@ -1,0 +1,75 @@
+package task
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+	"golang.org/x/image/font"
+)
+
+// DrawHUDWidgets 繪製任務 HUD（倒數字與圓形進度圈）。
+func (s *Scene) DrawHUDWidgets(dst *ebiten.Image, face font.Face, originX, originY int, theme Theme) {
+	// 倒數數字置於右上角圓形進度圈中心
+	sec := int((s.TimeLeftMs + 999) / 1000)
+	label := fmt.Sprintf("%ds", sec)
+	col := theme.Text
+	if sec%2 == 0 {
+		col = theme.Accent
+	}
+	w := s.width
+	cx := float32(originX + w - 18)
+	cy := float32(originY + 18)
+	r := float32(16)
+	// 先畫圓弧（避免覆蓋文字）
+	seg := 36
+	end := int(float32(seg) * s.Progress)
+	var px, py float32
+	for i := 0; i <= end; i++ {
+		ang := -float32(math.Pi/2) + 2*float32(math.Pi)*float32(i)/float32(seg)
+		x := cx + r*float32(math.Cos(float64(ang)))
+		y := cy + r*float32(math.Sin(float64(ang)))
+		if i > 0 {
+			vector.StrokeLine(dst, px, py, x, y, 2, theme.Accent, true)
+		}
+		px, py = x, y
+	}
+	// 再畫置中的倒數文字（在弧線上方），自動縮放以適配圓內
+	xf := text.NewGoXFace(face)
+	m := xf.Metrics()
+	tw, _ := text.Measure(label, xf, 0)
+	lineH := m.HAscent + m.HDescent
+	// 最大可用寬/高：使用圓的內徑（留 4px 邊距）
+	innerD := float64(2*r) - 4
+	if innerD < 6 {
+		innerD = 6
+	}
+	maxW := innerD
+	maxH := innerD
+	scale := 1.0
+	if float64(tw) > maxW || lineH > maxH {
+		sw := maxW / float64(tw)
+		sh := maxH / lineH
+		if sw < sh {
+			scale = sw
+		} else {
+			scale = sh
+		}
+		if scale < 0.7 { // 下限，避免過小難辨識
+			scale = 0.7
+		}
+	}
+	var op text.DrawOptions
+	op.GeoM.Scale(scale, scale)
+	// 以 baseline 對齊將文字垂直置中到 cy；水平置中到 cx
+	bx := float64(cx) - (float64(tw) * scale / 2)
+	by := float64(cy) + (m.HAscent*scale - (lineH*scale)/2)
+	// 視覺微調：大多數數字/字元沒有真正使用到全部 HDescent，高度會顯得偏下
+	// 因此以上移 HDescent 的一部分來校正
+	by -= m.HDescent * scale * 0.45
+	op.GeoM.Translate(bx, by)
+	op.ColorScale.ScaleWithColor(col)
+	text.Draw(dst, label, xf, &op)
+}

--- a/client/internal/game/task/practice.go
+++ b/client/internal/game/task/practice.go
@@ -1,0 +1,136 @@
+package task
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// practiceRenderer 呈現 goroutine × channel 的簡化視覺。
+type practiceRenderer struct {
+	totalMs int
+	leftMs  int
+	// 視覺狀態
+	spawnMs int
+	msgs    []Rect // 訊息小方塊（在主通道上移動）
+	// 群集匯流節奏
+	burstTickerMs int
+}
+
+func NewPracticeRenderer() Renderer { return &practiceRenderer{} }
+
+func (r *practiceRenderer) Sync(totalSec, remainingSec int64, _ int64) {
+	r.totalMs = int(totalSec * 1000)
+	r.leftMs = int(remainingSec * 1000)
+	if r.leftMs < 0 {
+		r.leftMs = 0
+	}
+	if r.totalMs <= 0 {
+		r.totalMs = 1
+	}
+}
+
+func (r *practiceRenderer) Update(dt time.Duration) {
+	// 基礎密度提升：更頻繁地生成
+	r.spawnMs -= int(dt / time.Millisecond)
+	if r.spawnMs <= 0 {
+		r.spawnMs = 220 + rand.Intn(160)
+		// 生成單一訊息
+		r.msgs = append(r.msgs, Rect{X: -1, Y: -1, W: 6, H: 6}) // 位置會在 Draw 前對齊到起點
+	}
+	// 每 ~2 秒做一次大量匯流
+	r.burstTickerMs -= int(dt / time.Millisecond)
+	if r.burstTickerMs <= 0 {
+		r.burstTickerMs = 2000 + rand.Intn(400)
+		// 一次性塞入多顆訊息，造成節點周邊密集
+		n := 4 + rand.Intn(4)
+		for i := 0; i < n; i++ {
+			r.msgs = append(r.msgs, Rect{X: -1, Y: -1, W: 6, H: 6})
+		}
+	}
+	// 推進既有訊息
+	for i := range r.msgs {
+		r.msgs[i].X += 1.0 // 稍微加速，純視覺
+	}
+	// 清掉超出範圍的（寬度未知，留給 Draw 做裁切）
+	if len(r.msgs) > 48 { // 上限保護
+		r.msgs = r.msgs[len(r.msgs)-48:]
+	}
+}
+
+func (r *practiceRenderer) Draw(dst *ebiten.Image, x, y, w, h int, theme Theme) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	// 背景通道（2 條）
+	pad := 10
+	laneY1 := float32(y + pad + 14)
+	laneY2 := float32(y + h - pad - 18)
+	vector.StrokeLine(dst, float32(x+pad), laneY1, float32(x+w-pad), laneY1, 1, theme.Grid, true)
+	vector.StrokeLine(dst, float32(x+pad), laneY2, float32(x+w-pad), laneY2, 1, theme.Grid, true)
+	// select 節點（中間一個，分支到下通道）
+	nodeX := float32(x + w/2)
+	vector.StrokeLine(dst, nodeX, laneY1, nodeX, laneY2, 1, theme.Accent, true)
+	// 節點徽章：阻塞/非阻塞（視覺偵測：節點附近訊息多且下通道擁擠時為 Warn）
+	nearCount := 0
+	lowerBusy := 0
+	for _, m := range r.msgs {
+		if absf(m.X-nodeX) < 8 {
+			nearCount++
+		}
+		if m.Y > laneY2-6 {
+			lowerBusy++
+		}
+	}
+	badgeCol := theme.Good
+	if nearCount >= 3 && lowerBusy >= 2 {
+		badgeCol = theme.Warn
+	}
+	// 小徽章畫在節點上方
+	vector.DrawFilledRect(dst, nodeX-3, laneY1-10, 6, 6, badgeCol, true)
+	// 訊息小方塊（只在上通道生成並通過節點往下漂）
+	progress := 1 - float32(r.leftMs)/float32(r.totalMs)
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 1 {
+		progress = 1
+	}
+	// 根據剩餘時間密度生成/位置對齊
+	if r.spawnMs <= 30 {
+		// 在通道起點生成
+		r.msgs = append(r.msgs, Rect{X: float32(x + pad), Y: laneY1 - 3, W: 6, H: 6})
+	}
+	for i := range r.msgs {
+		m := &r.msgs[i]
+		if m.X < 0 { // 初始對齊到起點
+			m.X = float32(x + pad)
+			m.Y = laneY1 - 3
+		}
+		// 當經過節點時（x > nodeX）緩慢往下靠攏
+		if float32(m.X) > nodeX-6 {
+			m.Y += 0.5
+			if m.Y > laneY2-3 {
+				m.Y = laneY2 - 3
+			}
+		}
+		// 繪製（視窗內才畫）
+		if float32(m.X) >= float32(x+pad) && float32(m.X) <= float32(x+w-pad) {
+			vector.DrawFilledRect(dst, m.X, m.Y, m.W, m.H, theme.Key, true)
+		}
+	}
+	// 進度匯流（底線）
+	px := float32(x + pad)
+	pw := float32(w - pad*2)
+	vector.StrokeLine(dst, px, float32(y+h-8), px+pw*progress, float32(y+h-8), 2, theme.Accent, true)
+}
+
+// absf returns absolute value for float32
+func absf(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/client/internal/game/task/renderer.go
+++ b/client/internal/game/task/renderer.go
@@ -1,0 +1,21 @@
+package task
+
+import (
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// Renderer 是任務動畫的渲染器介面，由 HUD 調用。
+// 契約：
+// - Sync 以 VM 的 total/remaining 為唯一真實來源；rewardK 供完成時視覺用。
+// - Update 僅推進本地微動畫（spawn、抖動等），不可自行推進進度。
+// - Draw 在給定矩形範圍內繪製，使用 Theme 色彩，不與 HUD 其他 UI 重疊。
+// - Renderer 不修改 VM 狀態。
+//
+// 注意：保持每幀零/極少配置，確保 60 FPS。
+type Renderer interface {
+	Sync(totalSec, remainingSec int64, rewardK int64)
+	Update(dt time.Duration)
+	Draw(dst *ebiten.Image, x, y, w, h int, theme Theme)
+}

--- a/client/internal/game/task/research.go
+++ b/client/internal/game/task/research.go
@@ -1,0 +1,91 @@
+package task
+
+import (
+	"math"
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// researchRenderer：Profiler/GC 波形 + 管線進度（無狀態、依時間/進度）。
+type researchRenderer struct {
+	totalSec     int64
+	remainingSec int64
+	rewardK      int64
+}
+
+func NewResearchRenderer() Renderer { return &researchRenderer{} }
+
+func (r *researchRenderer) Sync(totalSec, remainingSec int64, rewardK int64) {
+	r.totalSec = totalSec
+	r.remainingSec = remainingSec
+	r.rewardK = rewardK
+}
+func (r *researchRenderer) Update(dt time.Duration) {}
+
+func (r *researchRenderer) Draw(dst *ebiten.Image, x, y, w, h int, theme Theme) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	pad := 10
+	pct := float32(0)
+	if r.totalSec > 0 {
+		done := r.totalSec - r.remainingSec
+		if done < 0 {
+			done = 0
+		}
+		if done > r.totalSec {
+			done = r.totalSec
+		}
+		pct = float32(done) / float32(r.totalSec)
+	}
+	// 上半：管線
+	ph := (h - 2*pad) / 2
+	stages := 5
+	cell := (w - 2*pad) / stages
+	for i := 0; i < stages; i++ {
+		bx := float32(x + pad + i*cell + 6)
+		by := float32(y + pad + 6)
+		vector.StrokeRect(dst, bx, by, float32(cell-12), 14, 1, theme.Grid, true)
+		// 已完成比例（將任務進度映射到階段亮度/填充）
+		seg := float32(i+1) / float32(stages)
+		if pct >= seg {
+			vector.DrawFilledRect(dst, bx+1, by+1, float32(cell-14), 12, theme.Good, true)
+		} else if pct > seg-1.0/float32(stages) {
+			// 當前進行中的階段：部分填充
+			local := (pct - (seg - 1.0/float32(stages))) * float32(stages)
+			ww := int(float32(cell-14) * local)
+			if ww > 0 {
+				vector.DrawFilledRect(dst, bx+1, by+1, float32(ww), 12, theme.Accent, true)
+			}
+		}
+	}
+
+	// 下半：GC 掃描波與樣本方塊
+	baseY := float32(y + pad + ph + 8)
+	width := w - 2*pad
+	now := time.Now()
+	t := float32((now.UnixNano() % 1_000_000_000)) / 1_000_000_000
+	// 波形（2 條：主波與掃描線）
+	for i := 0; i < width; i++ {
+		x0 := float32(x + pad + i)
+		// 主波：慢速正弦，幅度 8
+		y0 := baseY + 4*float32(math.Sin(float64(i)*0.05+float64(t)*2.2))
+		vector.DrawFilledRect(dst, x0, y0, 1, 8, theme.Text, true)
+	}
+	// 掃描線：每 ~1.8s 從左到右掃過一次
+	sweep := int(float32(width) * float32(math.Mod(float64(t*0.55), 1.0)))
+	sx := float32(x + pad + sweep)
+	vector.DrawFilledRect(dst, sx, baseY-4, 2, 24, theme.Warn, true)
+
+	// 樣本方塊：依進度增加密度
+	step := int(math.Max(10, 28-18*float64(pct)))
+	if step < 6 {
+		step = 6
+	}
+	for i := 0; i < width; i += step {
+		hh := 6 + (i/step)%5
+		vector.DrawFilledRect(dst, float32(x+pad+i), baseY+20, 6, float32(hh), theme.Accent, true)
+	}
+}

--- a/client/internal/game/task/scene.go
+++ b/client/internal/game/task/scene.go
@@ -1,0 +1,140 @@
+package task
+
+import (
+	"time"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/vector"
+)
+
+// NewScene 建立一個基本模式（basic）場景。
+func NewScene(kind TaskKind, w, h int, rewardK int64, duration time.Duration) *Scene {
+	s := &Scene{
+		Kind:       kind,
+		Progress:   0,
+		TimeLeftMs: int(duration / time.Millisecond),
+		RewardK:    rewardK,
+		width:      w,
+		height:     h,
+		startX:     16,
+		endX:       float32(w - 32),
+	}
+	s.totalMs = s.TimeLeftMs
+	s.Key = Entity{
+		Rect:  Rect{X: s.startX, Y: float32(h/2 - 6), W: 12, H: 12},
+		Kind:  Key,
+		Alive: true,
+	}
+	return s
+}
+
+// Update 根據 dt 推進進度，並移動鑰匙。
+func (s *Scene) Update(dt time.Duration) {
+	if s.Progress >= 1 {
+		return
+	}
+	if s.TimeLeftMs > 0 {
+		s.TimeLeftMs -= int(dt / time.Millisecond)
+		if s.TimeLeftMs < 0 {
+			s.TimeLeftMs = 0
+		}
+	}
+	// 根據已流逝時間推進 progress（線性）
+	if s.totalMs > 0 {
+		elapsed := s.totalMs - s.TimeLeftMs
+		if elapsed < 0 {
+			elapsed = 0
+		}
+		if elapsed > s.totalMs {
+			elapsed = s.totalMs
+		}
+		s.Progress = float32(elapsed) / float32(s.totalMs)
+	}
+	if s.Progress > 1 {
+		s.Progress = 1
+	}
+	// 鑰匙位置：線性插值
+	x := s.startX + (s.endX-s.startX)*s.Progress
+	s.Key.Rect.X = x
+	// 小事件生成（視覺用）
+	s.Spawn(time.Now())
+}
+
+// SyncRemaining 與 VM 同步任務的總時長與剩餘時間（毫秒）。
+// 若 totalSec<=0 則忽略；remainingSec 會被夾在 [0, totalSec]。
+func (s *Scene) SyncRemaining(totalSec, remainingSec int64) {
+	if totalSec <= 0 {
+		return
+	}
+	totalMs := int(totalSec * 1000)
+	remMs := int(remainingSec * 1000)
+	if remMs < 0 {
+		remMs = 0
+	}
+	if remMs > totalMs {
+		remMs = totalMs
+	}
+	s.totalMs = totalMs
+	s.TimeLeftMs = remMs
+	// 依據同步後的時間重算進度
+	elapsed := totalMs - remMs
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	if elapsed > totalMs {
+		elapsed = totalMs
+	}
+	if totalMs > 0 {
+		s.Progress = float32(elapsed) / float32(totalMs)
+	} else {
+		s.Progress = 1
+	}
+	// 同步位置
+	s.Key.Rect.X = s.startX + (s.endX-s.startX)*s.Progress
+}
+
+// Draw 繪製網格、Key、終點方塊；完成時顯示 +K 漂浮字。
+func (s *Scene) Draw(dst *ebiten.Image, originX, originY int, theme Theme) {
+	// 繪製背景網格
+	for x := originX; x < originX+s.width; x += 12 {
+		vector.StrokeLine(dst, float32(x), float32(originY), float32(x), float32(originY+s.height), 1, theme.Grid, true)
+	}
+	for y := originY; y < originY+s.height; y += 12 {
+		vector.StrokeLine(dst, float32(originX), float32(y), float32(originX+s.width), float32(y), 1, theme.Grid, true)
+	}
+	// 目標方塊
+	vector.StrokeRect(dst, float32(originX+s.width-24), float32(originY+s.height/2-12), 20, 20, 2, theme.Goal, true)
+	// 鑰匙（用小方塊替代，與 HUD 風格一致）
+	vector.DrawFilledRect(dst, float32(originX)+s.Key.Rect.X, float32(originY)+s.Key.Rect.Y, s.Key.Rect.W, s.Key.Rect.H, theme.Key, true)
+	// 障礙與獎勵
+	for i := range s.Obstacles {
+		o := &s.Obstacles[i]
+		if !o.Alive {
+			continue
+		}
+		if i%2 == 0 {
+			o.Rect.Y += 0.2
+		} else {
+			o.Rect.Y -= 0.2
+		}
+		vector.DrawFilledRect(dst, float32(originX)+o.Rect.X, float32(originY)+o.Rect.Y, o.Rect.W, o.Rect.H, theme.Accent, true)
+	}
+	for i := range s.Bonuses {
+		b := &s.Bonuses[i]
+		if !b.Alive {
+			continue
+		}
+		vector.DrawFilledRect(dst, float32(originX)+b.Rect.X, float32(originY)+b.Rect.Y, b.Rect.W, b.Rect.H, theme.Bonus, true)
+	}
+	// 完成特效
+	if s.Progress >= 1 {
+		// 簡易星芒
+		cx := float32(originX + s.width - 14)
+		cy := float32(originY + s.height/2)
+		vector.StrokeLine(dst, cx-8, cy, cx+8, cy, 2, theme.Accent, true)
+		vector.StrokeLine(dst, cx, cy-8, cx, cy+8, 2, theme.Accent, true)
+	}
+}
+
+// 色彩 RGBA（避免與 HUD 依賴循環）
+// colorRGBA 已移除，改用 Theme 直接攜帶 color.RGBA

--- a/client/internal/game/task/spawn.go
+++ b/client/internal/game/task/spawn.go
@@ -1,0 +1,30 @@
+package task
+
+import (
+	"math/rand"
+	"time"
+)
+
+// Spawn 在 400~700ms 隨機生成視覺小物件。
+func (s *Scene) Spawn(now time.Time) {
+	if s.Progress >= 1 {
+		return
+	}
+	if s.spawnTickerMs <= 0 {
+		s.spawnTickerMs = 400 + rand.Intn(300)
+	}
+	s.spawnTickerMs -= 16 // 約略以 60fps 遞減
+	if s.spawnTickerMs > 0 {
+		return
+	}
+	s.spawnTickerMs = 400 + rand.Intn(300)
+	if rand.Float32() < 0.5 {
+		// spawn obstacle
+		y := float32(rand.Intn(s.height-24) + 12)
+		s.Obstacles = append(s.Obstacles, Entity{Rect: Rect{X: float32(rand.Intn(40)) + s.startX + 30, Y: y, W: 6, H: 6}, Kind: Obstacle, Alive: true})
+	} else {
+		// spawn bonus
+		y := float32(rand.Intn(s.height-24) + 12)
+		s.Bonuses = append(s.Bonuses, Entity{Rect: Rect{X: float32(rand.Intn(40)) + s.startX + 30, Y: y, W: 4, H: 4}, Kind: Bonus, Alive: true})
+	}
+}

--- a/client/internal/game/task/types.go
+++ b/client/internal/game/task/types.go
@@ -1,0 +1,62 @@
+package task
+
+import (
+	"image/color"
+)
+
+// TaskKind 描述任務類型。
+// Practice: 練習；Research: 研究；Deploy: 部署
+// 預留給未來擴充對應不同動畫風格。
+type TaskKind int
+
+const (
+	Practice TaskKind = iota
+	Research
+	Deploy
+)
+
+// EntityKind 場景中的物件種類。
+type EntityKind int
+
+const (
+	Key EntityKind = iota
+	Obstacle
+	Bonus
+)
+
+// Rect 與 Vel 為簡單的幾何結構。
+type Rect struct{ X, Y, W, H float32 }
+
+type Vel struct{ VX, VY float32 }
+
+// Entity 場景實體。
+type Entity struct {
+	Rect  Rect
+	Vel   Vel
+	Kind  EntityKind
+	Alive bool
+	Col   color.RGBA
+}
+
+// Scene 表示一個正在執行中的任務動畫場景。
+type Scene struct {
+	Kind       TaskKind
+	Obstacles  []Entity
+	Bonuses    []Entity
+	Progress   float32 // 0..1
+	TimeLeftMs int
+	RewardK    int64
+
+	// internal
+	width, height int
+	startX, endX  float32
+	spawnTickerMs int
+	totalMs       int
+	Key           Entity
+}
+
+// Theme 提供繪製時使用的色彩。
+type Theme struct {
+	Grid, Key, Goal, Bonus, Text, Accent color.RGBA
+	Good, Warn                           color.RGBA
+}

--- a/client/internal/ui/ai.go
+++ b/client/internal/ui/ai.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
-	"github.com/hajimehoshi/ebiten/v2/text"
 	"github.com/hajimehoshi/ebiten/v2/vector"
 	"golang.org/x/image/font"
 )
@@ -81,9 +80,8 @@ func DrawEvolvingAI(screen *ebiten.Image, face font.Face, x, y, w, h int, _ int6
 		if tag == "" {
 			tag = "go"
 		}
-		bounds, _ := font.BoundString(face, tag)
 		padX, padY := 6, 4
-		textW := int((bounds.Max.X - bounds.Min.X).Ceil())
+		textW := textWidth(face, tag)
 		textH := 14
 		tw := textW + padX*2
 		th := textH + padY*2
@@ -91,7 +89,7 @@ func DrawEvolvingAI(screen *ebiten.Image, face font.Face, x, y, w, h int, _ int6
 		tagY := y + h - th - 8
 		drawRoundedFilledRect(screen, tagX, tagY, tw, th, 6, Theme.CardBorder)
 		drawRoundedFilledRect(screen, tagX+1, tagY+1, tw-2, th-2, 5, pal.LabelBg)
-		text.Draw(screen, tag, face, tagX+padX, tagY+padY+12, color.Black)
+		drawText(screen, face, tag, tagX+padX, tagY+padY+12, color.RGBA{0, 0, 0, 255})
 	}
 }
 

--- a/client/internal/ui/app.go
+++ b/client/internal/ui/app.go
@@ -2,15 +2,20 @@ package ui
 
 import (
 	"context"
+	"fmt"
 	"image/color"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
-	"github.com/hajimehoshi/ebiten/v2/text"
+	"github.com/hajimehoshi/ebiten/v2/vector"
 	"golang.org/x/image/font"
 	"golang.org/x/image/font/basicfont"
+	"golang.org/x/image/font/opentype"
 
 	"go-ddd-architecture/client/internal/api/gameclient"
 )
@@ -41,22 +46,81 @@ type App struct {
 	// 輕量 Toast 提示（例如升級失敗）
 	toastMsg   atomic.Value // string
 	toastUntil atomic.Value // time.Time
+
+	// 升級成功的短暫脈動效果：記錄語言代碼 -> 截止時間
+	langPulses map[string]time.Time
+	pulseDur   time.Duration
+
+	// 任務完成後的簡短戰鬥動畫（成功：砍半；失敗：逃跑）
+	battleType  string    // "success" 或 "fail"
+	battleUntil time.Time // 顯示到期時間
+	battleLang  string    // which language style to use for battle effects
+	battleStyle int       // 1..N：不同式樣
+
+	// 任務完成獎勵的浮出台詞（+Knowledge）
+	floatText  string
+	floatUntil time.Time
+	floatStart time.Time
+
+	// 資源變化微動畫（Status 區 K/R 跳動與飄字）
+	prevK int64
+	prevR int64
+	// 本地跳動/飄字狀態
+	kBounceStart time.Time
+	kBounceUntil time.Time
+	rBounceStart time.Time
+	rBounceUntil time.Time
+	kFloatText   string
+	kFloatStart  time.Time
+	kFloatUntil  time.Time
+	rFloatText   string
+	rFloatStart  time.Time
+	rFloatUntil  time.Time
+
+	// Store 安裝動畫
+	prevServers     int
+	prevGPUs        int
+	serverAnimStart time.Time
+	serverAnimUntil time.Time
+	gpuAnimStart    time.Time
+	gpuAnimUntil    time.Time
+
+	// First-time tutorial overlay (dismissable)
+	showTutorial bool // 首次教學 Overlay（可略過）
+	showHotkeys  bool
+
+	// 語言排序模式與最近使用紀錄
+	// langSort: "lv" | "k" | "recent"
+	langSort        string
+	lastLangUsedAt  map[string]time.Time
+	prevCurrentLang string
+
+	// 本地 Task 視覺預覽（不影響後端）："deploy" | "research" | ""
+	taskPreview string
+
+	// 當前任務進行中時的排隊意圖："deploy" | "research"
+	nextTaskIntent string
 }
 
 func NewApp(api *gameclient.Client, state *State) *App {
 	return &App{
-		api:   api,
-		state: state,
-		face:  basicfont.Face7x13,
-		poll:  500 * time.Millisecond,
-		// 去抖：開始超過 150ms 才顯示；結束後保留 350ms
-		netHideDelay:   350 * time.Millisecond,
-		netShowLatency: 150 * time.Millisecond,
+		api:            api,
+		state:          state,
+		face:           loadUIFont(),
+		poll:           250 * time.Millisecond,
+		pulseDur:       300 * time.Millisecond,
+		netHideDelay:   300 * time.Millisecond,
+		netShowLatency: 120 * time.Millisecond,
+		showTutorial:   true,
+		showHotkeys:    true,
+		langSort:       "lv",
+		lastLangUsedAt: map[string]time.Time{},
 	}
 }
 
+// Update handles periodic polling and input.
 func (a *App) Update() error {
-	// 定期輪詢 viewmodel（非阻塞：若 busy 則跳過此輪）
+	// Periodic viewmodel polling (non-blocking)
 	if time.Since(a.lastVM) >= a.poll && !a.busy.Load() {
 		a.busy.Store(true)
 		a.netShowSince = time.Now()
@@ -75,7 +139,60 @@ func (a *App) Update() error {
 		}()
 	}
 
-	// 鍵盤事件（使用 inpututil 按下觸發一次）
+	// Tutorial overlay keys only
+	if a.showTutorial {
+		if inpututil.IsKeyJustPressed(ebiten.KeySpace) || inpututil.IsKeyJustPressed(ebiten.KeyEnter) || inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
+			a.showTutorial = false
+		}
+		if inpututil.IsKeyJustPressed(ebiten.KeyH) {
+			a.showHotkeys = !a.showHotkeys
+		}
+
+		// 本地任務視覺預覽切換（不呼叫後端）：Y 鍵在 practice(預設) → deploy → research → 關閉預覽 間循環
+		if inpututil.IsKeyJustPressed(ebiten.KeyY) {
+			switch a.taskPreview {
+			case "":
+				a.taskPreview = "deploy"
+				a.showToast("Preview: deploy")
+			case "deploy":
+				a.taskPreview = "research"
+				a.showToast("Preview: research")
+			default:
+				a.taskPreview = ""
+				a.showToast("Preview: off")
+			}
+		}
+		return nil
+	}
+
+	// Toggle hotkeys
+	if inpututil.IsKeyJustPressed(ebiten.KeyH) {
+		a.showHotkeys = !a.showHotkeys
+	}
+
+	// 語言排序快捷鍵：F 循環；V=Lv、K=Knowledge、R=Recent
+	if inpututil.IsKeyJustPressed(ebiten.KeyF) {
+		switch a.langSort {
+		case "lv":
+			a.langSort = "k"
+		case "k":
+			a.langSort = "recent"
+		default:
+			a.langSort = "lv"
+		}
+		a.showToast("Sort: " + a.langSort)
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyV) {
+		a.langSort = "lv"
+		a.showToast("Sort: lv")
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyK) {
+		a.langSort = "k"
+		a.showToast("Sort: k")
+	}
+	// 移除 R 做為排序快捷鍵，避免與 Research 任務熱鍵衝突。
+
+	// Keyboard actions
 	if inpututil.IsKeyJustPressed(ebiten.KeyP) && !a.busy.Load() {
 		a.trigger(func(ctx context.Context) error {
 			vm, err := a.api.PostStartPractice(ctx)
@@ -85,19 +202,101 @@ func (a *App) Update() error {
 			return err
 		})
 	}
-	// 移除 [F] 手動完成鍵，統一使用自動完成（任務倒數 <= 0 自動呼叫 TryFinish）
+	if inpututil.IsKeyJustPressed(ebiten.KeyT) && !a.busy.Load() {
+		a.trigger(func(ctx context.Context) error {
+			vm, err := a.api.PostStartTargeted(ctx)
+			if err == nil {
+				a.state.SetVM(vm)
+			}
+			return err
+		})
+	}
+
+	// D: Start Deploy, R: Start Research
+	if inpututil.IsKeyJustPressed(ebiten.KeyD) && !a.busy.Load() {
+		vmSnap, _ := a.state.Snapshot()
+		if vmSnap.CurrentTask != nil && vmSnap.CurrentTask.RemainingSeconds > 0 {
+			a.nextTaskIntent = "deploy"
+			a.showToast("Queued: Deploy (will start after current task)")
+		} else {
+			a.trigger(func(ctx context.Context) error {
+				vm, err := a.api.PostStartDeploy(ctx)
+				if err == nil {
+					a.state.SetVM(vm)
+					a.showToast("Started Deploy")
+				}
+				return err
+			})
+		}
+	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyR) && !a.busy.Load() {
+		vmSnap, _ := a.state.Snapshot()
+		if vmSnap.CurrentTask != nil && vmSnap.CurrentTask.RemainingSeconds > 0 {
+			a.nextTaskIntent = "research"
+			a.showToast("Queued: Research (will start after current task)")
+		} else {
+			a.trigger(func(ctx context.Context) error {
+				vm, err := a.api.PostStartResearch(ctx)
+				if err == nil {
+					a.state.SetVM(vm)
+					a.showToast("Started Research")
+				}
+				return err
+			})
+		}
+	}
+
+	// Mouse click actions for Store Buy buttons
+	if inpututil.IsMouseButtonJustPressed(ebiten.MouseButtonLeft) && !a.busy.Load() {
+		mx, my := ebiten.CursorPosition()
+		// Server Buy
+		if mx >= lastServerBuyRect.X && my >= lastServerBuyRect.Y && mx < lastServerBuyRect.X+lastServerBuyRect.W && my < lastServerBuyRect.Y+lastServerBuyRect.H {
+			a.trigger(func(ctx context.Context) error {
+				vm, err := a.api.PostBuyServer(ctx)
+				if err == nil {
+					a.state.SetVM(vm)
+					a.showToast("Purchased: Server (+slots)")
+					return nil
+				}
+				a.showToast("Need more Knowledge for Server")
+				return err
+			})
+		}
+		// GPU Buy
+		if mx >= lastGPUBuyRect.X && my >= lastGPUBuyRect.Y && mx < lastGPUBuyRect.X+lastGPUBuyRect.W && my < lastGPUBuyRect.Y+lastGPUBuyRect.H {
+			a.trigger(func(ctx context.Context) error {
+				vm, err := a.api.PostBuyGPU(ctx)
+				if err == nil {
+					a.state.SetVM(vm)
+					a.showToast("Purchased: GPU (+Research/min)")
+					return nil
+				}
+				a.showToast("Need slot or Knowledge for GPU")
+				return err
+			})
+		}
+	}
 	if inpututil.IsKeyJustPressed(ebiten.KeyU) && !a.busy.Load() {
+		prev, _ := a.state.Snapshot()
 		a.trigger(func(ctx context.Context) error {
 			vm, err := a.api.PostUpgradeKnowledge(ctx)
 			if err == nil {
 				a.state.SetVM(vm)
+				now := time.Now()
+				for code, after := range vm.Languages {
+					if before, ok := prev.Languages[code]; ok {
+						if after.Level > before.Level {
+							if a.langPulses == nil {
+								a.langPulses = map[string]time.Time{}
+							}
+							a.langPulses[code] = now.Add(a.pulseDur)
+						}
+					}
+				}
 				return nil
 			}
-			// 若為型別化 API 錯誤，判斷是否為 not_enough_research
-			// 直接用字串判斷，因 server 以 code: not_enough_research 回傳
 			if s := err.Error(); s != "" && (s == "not_enough_research: not enough research" || s == "not_enough_research") {
 				a.showToast("Not enough Research to upgrade")
-				// 不把此錯誤覆蓋到全域錯誤列，避免嚇人
 				return nil
 			}
 			return err
@@ -112,13 +311,13 @@ func (a *App) Update() error {
 			return err
 		})
 	}
-	// 語言切換：1->go, 2->py, 3->js（低風險、先提供三種預設）
+	// Language switching
 	if inpututil.IsKeyJustPressed(ebiten.Key1) && !a.busy.Load() {
 		a.trigger(func(ctx context.Context) error {
 			vm, err := a.api.PostSelectLanguage(ctx, "go")
 			if err == nil {
 				a.state.SetVM(vm)
-				a.showToast("切換到 Go")
+				a.showToast("Switched to Go")
 			}
 			return err
 		})
@@ -128,7 +327,7 @@ func (a *App) Update() error {
 			vm, err := a.api.PostSelectLanguage(ctx, "py")
 			if err == nil {
 				a.state.SetVM(vm)
-				a.showToast("切換到 Python")
+				a.showToast("Switched to Python")
 			}
 			return err
 		})
@@ -138,17 +337,46 @@ func (a *App) Update() error {
 			vm, err := a.api.PostSelectLanguage(ctx, "js")
 			if err == nil {
 				a.state.SetVM(vm)
-				a.showToast("切換到 JavaScript")
+				a.showToast("Switched to JavaScript")
 			}
 			return err
 		})
 	}
-	// 自動嘗試完成任務：剩餘時間 <= 0 即自動呼叫 TryFinish（不用再按 F）
+
+	// Auto practice/finish
 	if !a.busy.Load() {
 		vmSnap, _ := a.state.Snapshot()
-		// 自動啟動 practice：若沒有任務時自動發起（自我學習）
 		if vmSnap.CurrentTask == nil {
-			if a.autoPracticeKey == "" {
+			if a.nextTaskIntent != "" && !a.busy.Load() {
+				intent := a.nextTaskIntent
+				// 不使用 autoPracticeKey，避免與 practice 邏輯衝突
+				a.trigger(func(ctx context.Context) error {
+					var (
+						vm  gameclient.ViewModel
+						err error
+					)
+					switch intent {
+					case "deploy":
+						vm, err = a.api.PostStartDeploy(ctx)
+					case "research":
+						vm, err = a.api.PostStartResearch(ctx)
+					default:
+						// fallback: practice
+						vm, err = a.api.PostStartPractice(ctx)
+					}
+					if err == nil {
+						a.state.SetVM(vm)
+						if intent == "deploy" {
+							a.showToast("Started Deploy")
+						}
+						if intent == "research" {
+							a.showToast("Started Research")
+						}
+						a.nextTaskIntent = ""
+					}
+					return err
+				})
+			} else if a.autoPracticeKey == "" {
 				a.autoPracticeKey = "inflight"
 				a.trigger(func(ctx context.Context) error {
 					vm, err := a.api.PostStartPractice(ctx)
@@ -159,7 +387,6 @@ func (a *App) Update() error {
 				})
 			}
 		}
-
 		if vmSnap.CurrentTask != nil && vmSnap.CurrentTask.RemainingSeconds <= 0 {
 			key := vmSnap.CurrentTask.ID + "|" + vmSnap.CurrentTask.EndsAt
 			if key != "" && key != a.autoFinishKey {
@@ -168,21 +395,35 @@ func (a *App) Update() error {
 					out, err := a.api.PostTryFinish(ctx)
 					if err == nil {
 						a.state.SetVM(out.ViewModel)
+						if out.Finished {
+							if vmSnap.CurrentTask != nil && vmSnap.CurrentTask.Language != "" {
+								a.battleLang = vmSnap.CurrentTask.Language
+							} else {
+								a.battleLang = out.ViewModel.CurrentLanguage
+							}
+							r := rand.New(rand.NewSource(time.Now().UnixNano()))
+							a.battleStyle = 1 + r.Intn(3)
+							if out.Reward > 0 {
+								a.battleType = "success"
+								a.floatText = fmt.Sprintf("+%d K", out.Reward)
+								a.floatStart = time.Now()
+								a.floatUntil = a.floatStart.Add(800 * time.Millisecond)
+							} else {
+								a.battleType = "fail"
+							}
+							a.battleUntil = time.Now().Add(700 * time.Millisecond)
+						}
 					}
 					return err
 				})
 			}
 		}
-		// 若沒有任務，清空 key（允許下一個任務再觸發）
 		if vmSnap.CurrentTask == nil {
 			a.autoFinishKey = ""
-			// 若伺服器已回應新任務，清除 practice 去重
 			if a.autoPracticeKey != "" {
-				// 仍保持去重直到下一輪確認
-				// (在下一次沒有任務時會再觸發)
+				// keep until next cycle
 			}
 		} else {
-			// 當存在任務時可以重置 practice 去重，允許未來重新啟動
 			a.autoPracticeKey = ""
 		}
 	}
@@ -206,6 +447,55 @@ func (a *App) trigger(fn func(ctx context.Context) error) {
 
 func (a *App) Draw(screen *ebiten.Image) {
 	vm, errMsg := a.state.Snapshot()
+	// 偵測資源變化（只在變大時觸發跳動與飄字）
+	nowAnim := time.Now()
+	if a.prevK == 0 && vm.Knowledge > 0 {
+		a.prevK = vm.Knowledge
+	}
+	if a.prevR == 0 && vm.Research > 0 {
+		a.prevR = vm.Research
+	}
+	if dk := vm.Knowledge - a.prevK; dk > 0 {
+		a.kBounceStart = nowAnim
+		a.kBounceUntil = nowAnim.Add(300 * time.Millisecond)
+		a.kFloatText = fmt.Sprintf("+%d", dk)
+		a.kFloatStart = nowAnim
+		a.kFloatUntil = nowAnim.Add(700 * time.Millisecond)
+		a.prevK = vm.Knowledge
+	} else if vm.Knowledge < a.prevK {
+		a.prevK = vm.Knowledge
+	}
+	if dr := vm.Research - a.prevR; dr > 0 {
+		a.rBounceStart = nowAnim
+		a.rBounceUntil = nowAnim.Add(300 * time.Millisecond)
+		a.rFloatText = fmt.Sprintf("+%d", dr)
+		a.rFloatStart = nowAnim
+		a.rFloatUntil = nowAnim.Add(700 * time.Millisecond)
+		a.prevR = vm.Research
+	} else if vm.Research < a.prevR {
+		a.prevR = vm.Research
+	}
+	// 偵測 Store 變化
+	if a.prevServers == 0 && vm.Servers > 0 {
+		a.prevServers = vm.Servers
+	}
+	if a.prevGPUs == 0 && vm.GPUs > 0 {
+		a.prevGPUs = vm.GPUs
+	}
+	if vm.Servers > a.prevServers {
+		a.serverAnimStart = nowAnim
+		a.serverAnimUntil = nowAnim.Add(500 * time.Millisecond)
+		a.prevServers = vm.Servers
+	} else if vm.Servers < a.prevServers {
+		a.prevServers = vm.Servers
+	}
+	if vm.GPUs > a.prevGPUs {
+		a.gpuAnimStart = nowAnim
+		a.gpuAnimUntil = nowAnim.Add(500 * time.Millisecond)
+		a.prevGPUs = vm.GPUs
+	} else if vm.GPUs < a.prevGPUs {
+		a.prevGPUs = vm.GPUs
+	}
 	// 轉成 HUD VM
 	hudVM := VM{
 		Knowledge:        vm.Knowledge,
@@ -215,9 +505,42 @@ func (a *App) Draw(screen *ebiten.Image) {
 		KnowledgePerMin:  vm.KnowledgePerMin,
 		ResearchPerMin:   vm.ResearchPerMin,
 		EstimatedSuccess: vm.EstimatedSuccess,
+		Servers:          vm.Servers,
+		GPUs:             vm.GPUs,
+		Slots:            vm.Slots,
+		ShowHotkeys:      a.showHotkeys,
+		LangSort:         a.langSort,
+		TaskPreview:      a.taskPreview,
 	}
+	// 將動畫狀態灌入 HUD VM
+	hudVM.KBounceStart = a.kBounceStart
+	hudVM.KBounceUntil = a.kBounceUntil
+	hudVM.RBounceStart = a.rBounceStart
+	hudVM.RBounceUntil = a.rBounceUntil
+	hudVM.KFloatText = a.kFloatText
+	hudVM.KFloatStart = a.kFloatStart
+	hudVM.KFloatUntil = a.kFloatUntil
+	hudVM.RFloatText = a.rFloatText
+	hudVM.RFloatStart = a.rFloatStart
+	hudVM.RFloatUntil = a.rFloatUntil
+	hudVM.ServerAnimStart = a.serverAnimStart
+	hudVM.ServerAnimUntil = a.serverAnimUntil
+	hudVM.GPUAnimStart = a.gpuAnimStart
+	hudVM.GPUAnimUntil = a.gpuAnimUntil
 	// 傳遞多語言資訊給 HUD（固定順序 go/py/js 若存在）
 	hudVM.CurrentLanguage = vm.CurrentLanguage
+	// 更新最近使用語言時間（偵測變更）
+	if vm.CurrentLanguage != "" && vm.CurrentLanguage != a.prevCurrentLang {
+		a.lastLangUsedAt[vm.CurrentLanguage] = time.Now()
+		a.prevCurrentLang = vm.CurrentLanguage
+	}
+	// 傳遞最近使用的時間戳（unix 秒）供 HUD 排序
+	if len(a.lastLangUsedAt) > 0 {
+		hudVM.LangRecent = map[string]int64{}
+		for code, t := range a.lastLangUsedAt {
+			hudVM.LangRecent[code] = t.Unix()
+		}
+	}
 	if len(vm.Languages) > 0 {
 		hudVM.Languages = map[string]LangHUD{}
 		if s, ok := vm.Languages["go"]; ok {
@@ -246,6 +569,30 @@ func (a *App) Draw(screen *ebiten.Image) {
 			BaseReward:       vm.CurrentTask.BaseReward,
 		}
 	}
+	// 清理過期脈動並傳遞給 HUD
+	now2 := time.Now()
+	if len(a.langPulses) > 0 {
+		for k, until := range a.langPulses {
+			if now2.After(until) {
+				delete(a.langPulses, k)
+			}
+		}
+		if len(a.langPulses) > 0 {
+			// 複製一份傳遞，避免資料競態
+			p := make(map[string]time.Time, len(a.langPulses))
+			for k, v := range a.langPulses {
+				p[k] = v
+			}
+			hudVM.Pulses = p
+		}
+	}
+	// 戰鬥動畫狀態傳遞（僅在有效期間內傳給 HUD）
+	if !a.battleUntil.IsZero() && time.Now().Before(a.battleUntil) {
+		hudVM.BattleType = a.battleType
+		hudVM.BattleUntil = a.battleUntil
+		hudVM.BattleLang = a.battleLang
+		hudVM.BattleStyle = a.battleStyle
+	}
 	// 去抖後的網路顯示：開始超過門檻才顯示；結束後保留一段時間
 	inFlight := a.busy.Load()
 	now := time.Now()
@@ -264,21 +611,121 @@ func (a *App) Draw(screen *ebiten.Image) {
 		// 位置：靠近卡片底部稍微往下
 		x := Theme.Pad8 * 2
 		y := Theme.Pad8*2 + 320 + Theme.Pad8 + 92 + Theme.Pad8 + 12 // Status 卡 + Task 卡 + padding
-		ebitenutilDrawText(screen, a.face, toast, x, y, Theme.Good)
+		// 使用 HUD 的封裝繪字（含 baseline 調整）
+		drawText(screen, a.face, toast, x, y, Theme.Good)
+	}
+
+	// 浮出 +Knowledge 數字（位於畫面中央，往上飄並淡出）
+	if a.floatText != "" && !a.floatUntil.IsZero() {
+		now := time.Now()
+		if now.Before(a.floatUntil) {
+			dur := a.floatUntil.Sub(a.floatStart).Seconds()
+			t := now.Sub(a.floatStart).Seconds() / dur
+			if t < 0 {
+				t = 0
+			}
+			if t > 1 {
+				t = 1
+			}
+			sw, sh := screen.Size()
+			y0 := sh/2 + 10
+			y1 := sh/2 - 30
+			y := int(float64(y0) + (float64(y1-y0) * t))
+			alpha := uint8(255 * (1.0 - t))
+			col := color.RGBA{R: Theme.Accent.R, G: Theme.Accent.G, B: Theme.Accent.B, A: alpha}
+			x := (sw - textWidth(a.face, a.floatText)) / 2
+			drawText(screen, a.face, a.floatText, x, y, col)
+		} else {
+			a.floatText = ""
+		}
 	}
 
 	// 目前移除右側 AI 顯示（暫時不影響遊戲設計）
 	// 若日後恢復，請在此重新計算位置並呼叫 DrawEvolvingAI
+
+	// Tutorial overlay
+	if a.showTutorial {
+		sw, sh := screen.Size()
+		overlay := color.RGBA{0, 0, 0, 140}
+		vector.DrawFilledRect(screen, 0, 0, float32(sw), float32(sh), overlay, true)
+		w := min(sw-120, 640)
+		h := 220
+		x := (sw - w) / 2
+		y := (sh - h) / 2
+		drawRoundedFilledRect(screen, x, y, w, h, 8, Theme.CardBg)
+		drawRoundedRectOutline(screen, x, y, w, h, 8, Theme.OutlineBlue, 1)
+		tx := x + Theme.Pad8
+		ty := y + Theme.Pad8 + 12
+		drawText(screen, a.face, "Quick Tour", tx, ty, Theme.TextMain)
+		ty += 16
+		vector.StrokeLine(screen, float32(tx), float32(ty), float32(x+w-Theme.Pad8), float32(ty), 1, Theme.CardBorder, true)
+		ty += 12
+		lines := []string{
+			"Welcome! This is a tiny practice-and-unlock game.",
+			"Left Status shows resources and level; center Task starts/waits tasks.",
+			"Use keys: P practice, T targeted, D deploy, R research; U upgrade; C claim.",
+			"Click Buy to purchase hardware (Server/GPU).",
+		}
+		for _, s := range lines {
+			drawText(screen, a.face, s, tx, ty, Theme.TextSub)
+			ty += 18
+		}
+		hint := "Press Space / Enter / Esc to dismiss"
+		drawText(screen, a.face, hint, x+w-textWidth(a.face, hint)-Theme.Pad8, y+h-Theme.Pad8, Theme.TextSub)
+	}
 }
 
-// ebitenutilDrawText 是簡化版文字繪製封裝，避免重複 import text 包（此檔已 import）
-// 這裡直接用 text.Draw，作為單行字的便利函式。
-func ebitenutilDrawText(dst *ebiten.Image, face font.Face, s string, x, y int, col color.RGBA) {
-	text.Draw(dst, s, face, x, y, col)
-}
+// 移除舊版 ebitenutilDrawText，統一改用 text/v2 DrawOptions 於呼叫點處理。
 
 func (a *App) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeight int) {
 	return 960, 540
+}
+
+// loadUIFont 嘗試載入支援中文的字型（優先 APP_UI_FONT 指定的檔案），找不到時退回 basicfont。
+func loadUIFont() font.Face {
+	// 1) 環境變數指定檔案路徑
+	if p := os.Getenv("APP_UI_FONT"); p != "" {
+		if f := openTTFFace(p, 14); f != nil {
+			return f
+		}
+	}
+	// 2) 專案常見路徑候選
+	candidates := []string{
+		"assets/fonts/NotoSansTC-Regular.ttf",
+		"assets/fonts/NotoSansSC-Regular.ttf",
+		"assets/fonts/SourceHanSansTC-Regular.otf",
+		"assets/fonts/SourceHanSans-Regular.otf",
+		"client/assets/fonts/NotoSansTC-Regular.ttf",
+		"client/assets/fonts/NotoSansSC-Regular.ttf",
+		"client/assets/fonts/SourceHanSansTC-Regular.otf",
+		"client/assets/fonts/SourceHanSans-Regular.otf",
+	}
+	cwd, _ := os.Getwd()
+	for _, rel := range candidates {
+		p := filepath.Join(cwd, rel)
+		if f := openTTFFace(p, 14); f != nil {
+			return f
+		}
+	}
+	// 3) 退回內建等寬字：不支援中文，但至少不會崩潰
+	return basicfont.Face7x13
+}
+
+// openTTFFace 讀取 TTF/OTF 字型，回傳 Face；失敗則回 nil。
+func openTTFFace(path string, size float64) font.Face {
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	ft, err := opentype.Parse(data)
+	if err != nil {
+		return nil
+	}
+	face, err := opentype.NewFace(ft, &opentype.FaceOptions{Size: size, DPI: 72})
+	if err != nil {
+		return nil
+	}
+	return face
 }
 
 // showToast 顯示一則短暫提示訊息（1.5 秒）。

--- a/client/internal/ui/hud.go
+++ b/client/internal/ui/hud.go
@@ -4,169 +4,597 @@ import (
 	"fmt"
 	"image/color"
 	"math"
+	"sort"
 	"time"
 
+	gametask "go-ddd-architecture/client/internal/game/task"
+
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/text"
+	"github.com/hajimehoshi/ebiten/v2/text/v2"
 	"github.com/hajimehoshi/ebiten/v2/vector"
 	"golang.org/x/image/font"
 )
+
+// 任務區塊的場景渲染暫時停用（移除 mini game 與圓形倒數）
+
+// 用於讓 App.Update() 取得本幀 Store Buy 按鈕的點擊區域
+type uiRect struct{ X, Y, W, H int }
+
+var (
+	lastServerBuyRect uiRect
+	lastGPUBuyRect    uiRect
+)
+
+// 防止單檔靜態檢查誤判未使用（跨檔案會使用）
+func init() {
+	_ = lastServerBuyRect
+	_ = lastGPUBuyRect
+}
 
 // DrawHUD draws the main HUD: resources, level, current task timer, etc.
 func DrawHUD(screen *ebiten.Image, face font.Face, vm VM, errMsg string, inFlight bool) {
 	// background
 	screen.Fill(Theme.Bg)
 
-	sw, sh := screen.Size()
+	b := screen.Bounds()
+	sw, sh := b.Dx(), b.Dy()
 	pad := Theme.Pad8
+	// 內距至少 10px（P1 要求）
+	innerPad := max(pad, 10)
 
-	// layout widths
+	// layout widths（響應式調整，避免右側被切到）
 	leftW := 280
 	rightW := 260
-	// center width fills remaining space with padding
-	centerW := sw - leftW - rightW - pad*6
-	if centerW < 240 {
-		centerW = 240
+	minLeft, minCenter, minRight := 220, 160, 200
+	// 先以預設寬度計算 center；預留左右外側各 pad*2 與兩欄間隔 pad*2，共 pad*8
+	centerW := sw - leftW - rightW - pad*8
+	if centerW < minCenter {
+		// 需要壓縮左右欄寬度以讓中欄至少保有最小寬度
+		deficit := minCenter - centerW
+		// 優先縮右欄
+		shrinkR := min(deficit, rightW-minRight)
+		rightW -= shrinkR
+		deficit -= shrinkR
+		// 再縮左欄
+		if deficit > 0 {
+			shrinkL := min(deficit, leftW-minLeft)
+			leftW -= shrinkL
+			deficit -= shrinkL
+		}
+		// 重新計算 centerW；若仍小於 minCenter，維持實際剩餘寬度以避免溢出
+		centerW = sw - leftW - rightW - pad*8
 	}
 
-	// Left: Status card
+	// Left: Status card with light blue outline
 	leftX, leftY := pad*2, pad*2
 	leftH := 220
 	drawCard(screen, leftX, leftY, leftW, leftH)
-	tx, ty := leftX+pad, leftY+pad+14
-	text.Draw(screen, "Status", face, tx, ty, Theme.TextMain)
+	// 額外淡藍描邊
+	drawRoundedRectOutline(screen, leftX, leftY, leftW, leftH, Theme.Radius8, Theme.OutlineBlue, 1)
+	tx, ty := leftX+innerPad, leftY+innerPad+14
+	drawText(screen, face, "Status", tx, ty, Theme.TextMain)
+	// Models badge: count languages as owned models
+	models := len(vm.Languages)
+	if models > 0 {
+		mtxt := fmt.Sprintf("Models %d", models)
+		mw := 6*2 + textWidth(face, mtxt)
+		drawBadge(screen, leftX+leftW-innerPad-mw, ty-12, mtxt, face, true)
+	}
 	ty += 8
-	vector.StrokeLine(screen, float32(tx), float32(ty), float32(leftX+leftW-pad), float32(ty), 1, Theme.CardBorder, true)
+	vector.StrokeLine(screen, float32(tx), float32(ty), float32(leftX+leftW-innerPad), float32(ty), 1, Theme.CardBorder, true)
 	ty += 12
-	text.Draw(screen, fmt.Sprintf("Knowledge: %d", vm.Knowledge), face, tx, ty, Theme.TextMain)
+	// Knowledge 行（含小幅跳動與飄字）
+	drawText(screen, face, "Knowledge: ", tx, ty, Theme.TextMain)
+	nK := fmt.Sprintf("%d", vm.Knowledge)
+	kx := tx + textWidth(face, "Knowledge: ")
+	ky := ty + bounceYOffset(vm.KBounceStart, vm.KBounceUntil, 3)
+	// 放大強調（藍色）
+	drawTextScaled(screen, face, nK, kx, ky, color.RGBA{0x58, 0xB8, 0xFF, 0xFF}, 1.25)
+	// +K 飄字
+	if vm.KFloatText != "" && !vm.KFloatStart.IsZero() && time.Now().Before(vm.KFloatUntil) {
+		t := timeProgress(vm.KFloatStart, vm.KFloatUntil)
+		fx := kx + textWidth(face, nK) + 10
+		fy := ky - 6 - int(12*t)
+		alpha := uint8(255 * (1 - t))
+		col := color.RGBA{R: 0x58, G: 0xB8, B: 0xFF, A: alpha}
+		drawText(screen, face, vm.KFloatText, fx, fy, col)
+	}
 	ty += 18
-	text.Draw(screen, fmt.Sprintf("Research:  %d", vm.Research), face, tx, ty, Theme.TextMain)
+	// Research 行（含小幅跳動與飄字）
+	drawText(screen, face, "Research:  ", tx, ty, Theme.TextMain)
+	nR := fmt.Sprintf("%d", vm.Research)
+	rx := tx + textWidth(face, "Research:  ")
+	ry := ty + bounceYOffset(vm.RBounceStart, vm.RBounceUntil, 3)
+	// 放大強調（綠色）
+	drawTextScaled(screen, face, nR, rx, ry, color.RGBA{0x6B, 0xE5, 0x9C, 0xFF}, 1.25)
+	// +R 飄字
+	if vm.RFloatText != "" && !vm.RFloatStart.IsZero() && time.Now().Before(vm.RFloatUntil) {
+		t := timeProgress(vm.RFloatStart, vm.RFloatUntil)
+		fx := rx + textWidth(face, nR) + 10
+		fy := ry - 6 - int(12*t)
+		alpha := uint8(255 * (1 - t))
+		col := color.RGBA{R: 0x6B, G: 0xE5, B: 0x9C, A: alpha}
+		drawText(screen, face, vm.RFloatText, fx, fy, col)
+	}
 	ty += 18
-	text.Draw(screen, fmt.Sprintf("Level: %d", vm.Level), face, tx, ty, Theme.TextMain)
+	drawText(screen, face, "Level: ", tx, ty, Theme.TextMain)
+	nLv := fmt.Sprintf("%d", vm.Level)
+	// 放大強調（橘色）
+	drawTextScaled(screen, face, nLv, tx+textWidth(face, "Level: "), ty, color.RGBA{0xFF, 0xB3, 0x6B, 0xFF}, 1.25)
 	costStr := fmt.Sprintf("Cost R %d", vm.NextUpgradeCost)
-	cb := text.BoundString(face, costStr)
-	badgeW := 6*2 + cb.Dx()
+	badgeW := 6*2 + textWidth(face, costStr)
 	drawBadge(screen, leftX+leftW-pad-badgeW, ty-12, costStr, face, canAfford(vm))
 	ty += 22
-	text.Draw(screen, fmt.Sprintf("Rates K/R per min: %d / %d", vm.KnowledgePerMin, vm.ResearchPerMin), face, tx, ty, Theme.TextSub)
+	drawText(screen, face, fmt.Sprintf("Rates K/R per min: %d / %d", vm.KnowledgePerMin, vm.ResearchPerMin), tx, ty, Theme.TextSub)
+	ty += 18
+	// Hardware bonus: GPUs increase R/min
+	bonus := vm.GPUs * GPUBonusRPM
+	drawText(screen, face, fmt.Sprintf("HW bonus R/min: +%d (GPUs %d x %d)", bonus, vm.GPUs, GPUBonusRPM), tx, ty, Theme.TextSub)
 	ty += 18
 	if vm.EstimatedSuccess > 0 {
-		text.Draw(screen, fmt.Sprintf("Est. Success: %.0f%%", vm.EstimatedSuccess*100), face, tx, ty, Theme.TextSub)
+		drawText(screen, face, fmt.Sprintf("Est. Success: %.0f%%", vm.EstimatedSuccess*100), tx, ty, Theme.TextSub)
 		ty += 22
 	}
 
 	// Networking / Error in left card bottom area
-	nx := leftX + pad
-	ny := leftY + leftH - pad - 36
+	nx := leftX + innerPad
+	ny := leftY + leftH - innerPad - 36
 	if inFlight {
-		text.Draw(screen, "Networking...", face, nx, ny, Theme.Good)
+		// "Networking..." with bouncing dots
+		base := "Networking"
+		drawText(screen, face, base, nx, ny, Theme.Good)
+		dotsX := nx + textWidth(face, base) + 8
+		dotsY := ny - 6
+		now := time.Now()
+		period := float64(1200 * time.Millisecond)
+		for i := 0; i < 3; i++ {
+			t := float64(now.UnixNano()%int64(period)) / period
+			phase := t + float64(i)/3 // 相位差
+			yoff := -2.5 * math.Sin(2*math.Pi*phase)
+			x := float32(dotsX + i*8)
+			vector.DrawFilledCircle(screen, x, float32(dotsY)+float32(yoff), 2, Theme.Good, true)
+		}
 		ny += 18
 	}
 	if errMsg != "" {
-		text.Draw(screen, "Error: "+errMsg, face, nx, ny, Theme.Error)
+		drawText(screen, face, "Error: "+errMsg, nx, ny, Theme.Error)
 		ny += 18
 	}
 
-	// Center: Task (top) + Shiba (bottom)
+	// 取得滑鼠位置，供 hover 判斷
+	mx, my := ebiten.CursorPosition()
+
+	// Center: Unified Task block（取代原進度條與獨立戰鬥視覺）
 	centerX := leftX + leftW + pad*2
 	centerY := leftY
-	taskH := 140
+	// 以左側 Status+Store 高度為基準底線
+	baselineBottom := leftY + leftH + pad + 160 // 160 為 Store 高度
+	// 不預留 Hotkeys 橫條高度，Task 直接拉到底
+	taskH := baselineBottom - centerY
+	if taskH < 160 {
+		taskH = 160
+	}
 	drawCard(screen, centerX, centerY, centerW, taskH)
-	ttx, tty := centerX+pad, centerY+pad+12
+	drawRoundedRectOutline(screen, centerX, centerY, centerW, taskH, Theme.Radius8, Theme.OutlineBlue, 1)
+	// Blueprint background grid (subtle)
+	drawBlueprintGrid(screen, centerX+1, centerY+1, centerW-2, taskH-2)
+	ttx, tty := centerX+innerPad, centerY+innerPad+12
 	if vm.CurrentTask != nil {
 		title := "Task: " + vm.CurrentTask.Type
 		if vm.CurrentTask.Language != "" {
 			title += " [" + vm.CurrentTask.Language + "]"
 		}
-		text.Draw(screen, title, face, ttx, tty, Theme.TextMain)
+		drawText(screen, face, title, ttx, tty, Theme.TextMain)
+		// Type tag at top-right of task card
+		if vm.CurrentTask.Type != "" {
+			tag := vm.CurrentTask.Type
+			tw := 12 + textWidth(face, tag)
+			drawBadge(screen, centerX+centerW-pad-tw, centerY+pad, tag, face, true)
+		}
 		tty += 16
 		if vm.CurrentTask.Language != "" {
 			startLabel := "Started: " + vm.CurrentTask.Language
 			if vm.CurrentLanguage != "" && vm.CurrentLanguage != vm.CurrentTask.Language {
 				startLabel += " (now: " + vm.CurrentLanguage + ")"
 			}
-			text.Draw(screen, startLabel, face, ttx, tty, Theme.Good)
+			drawText(screen, face, startLabel, ttx, tty, Theme.Good)
 			tty += 16
 		} else {
 			tty += 2
 		}
+		// P2: 顯示進度提示
 		if vm.CurrentTask.BaseReward > 0 {
-			text.Draw(screen, fmt.Sprintf("Base +%d K", vm.CurrentTask.BaseReward), face, ttx, tty, Theme.TextSub)
+			hint := fmt.Sprintf("Task in progress: +%dK", vm.CurrentTask.BaseReward)
+			drawText(screen, face, hint, ttx, tty, Theme.TextSub)
 			tty += 16
 		}
-		if vm.CurrentTask.DurationSeconds > 0 {
-			text.Draw(screen, fmt.Sprintf("Duration: %ds", vm.CurrentTask.DurationSeconds), face, ttx, tty, Theme.TextSub)
-		}
-		// radial timer on the right side of the task card
+		// P1: 小遊戲進度（鑰匙 -> 目標方塊）
 		remain := vm.CurrentTask.RemainingSeconds
-		cx := centerX + centerW - pad - 40
-		cy := centerY + taskH/2
-		ratio := float32(remain%60) / 60.0
-		if remain <= 10 {
-			drawArcRing(screen, cx, cy, 20, ratio, Theme.Warn, Theme.Warn)
-		} else {
-			drawArcRing(screen, cx, cy, 20, ratio, Theme.Good, Theme.Warn)
+		total := vm.CurrentTask.DurationSeconds
+		var pct float32
+		if total > 0 {
+			elapsed := total - remain
+			if elapsed < 0 {
+				elapsed = 0
+			}
+			pct = float32(elapsed) / float32(total)
+			if pct < 0 {
+				pct = 0
+			} else if pct > 1 {
+				pct = 1
+			}
 		}
-		label := fmt.Sprintf("%02d:%02d", remain/60, remain%60)
-		b := text.BoundString(face, label)
-		lx := cx - b.Dx()/2
-		ly := cy + 5
-		text.Draw(screen, label, face, lx, ly, Theme.TextSub)
+		// 區域（渲染 Practice MVP，不使用圓形倒數）
+		areaX := centerX + innerPad
+		areaY := centerY + innerPad + 64
+		areaW := centerW - innerPad*2
+		areaH := taskH - (areaY - centerY) - pad
+		// 建立渲染器（暫時每幀建構輕量物件，之後可升級為單例）
+		var renderer gametask.Renderer
+		// 先看本地預覽覆寫（若有）
+		rtype := vm.CurrentTask.Type
+		if vm.TaskPreview != "" {
+			rtype = vm.TaskPreview
+		}
+		switch rtype {
+		case "deploy", "Deploy", "DEPLOY":
+			renderer = gametask.NewDeployRenderer()
+		case "research", "Research", "RESEARCH":
+			renderer = gametask.NewResearchRenderer()
+		default:
+			renderer = gametask.NewPracticeRenderer()
+		}
+		renderer.Sync(vm.CurrentTask.DurationSeconds, vm.CurrentTask.RemainingSeconds, vm.CurrentTask.BaseReward)
+		renderer.Update(16 * time.Millisecond)
+		// Theme 映射
+		theme := gametask.Theme{
+			Grid:   Theme.CardBorder,
+			Key:    Theme.TextMain,
+			Goal:   Theme.TextSub,
+			Bonus:  Theme.Accent,
+			Text:   Theme.TextSub,
+			Accent: Theme.Accent,
+			Good:   Theme.Good,
+			Warn:   Theme.Warn,
+		}
+		renderer.Draw(screen, areaX, areaY, areaW, areaH, theme)
 	} else {
-		text.Draw(screen, "No active task", face, ttx, tty, Theme.TextSub)
+		drawText(screen, face, "No active task", ttx, tty, Theme.TextSub)
+		// Offer Practice button (mouse hover supported)
+		btnW := 14 + textWidth(face, "Practice")
+		btnH := 24
+		bx := ttx
+		by := tty + 10
+		hovered := pointInRect(mx, my, bx, by-16, btnW, btnH)
+		drawButton(screen, bx, by-16, btnW, btnH, "Practice", face, true, hovered)
+		// 若有本地預覽，仍渲染預覽內容（deploy/research skeleton）
+		if vm.TaskPreview != "" {
+			areaX := centerX + innerPad
+			areaY := centerY + innerPad + 64
+			areaW := centerW - innerPad*2
+			areaH := taskH - (areaY - centerY) - pad
+			var renderer gametask.Renderer
+			switch vm.TaskPreview {
+			case "deploy":
+				renderer = gametask.NewDeployRenderer()
+			case "research":
+				renderer = gametask.NewResearchRenderer()
+			default:
+				renderer = gametask.NewPracticeRenderer()
+			}
+			renderer.Sync(20, 10, 5)
+			renderer.Update(16 * time.Millisecond)
+			theme := gametask.Theme{Grid: Theme.CardBorder, Key: Theme.TextMain, Goal: Theme.TextSub, Bonus: Theme.Accent, Text: Theme.TextSub, Accent: Theme.Accent, Good: Theme.Good, Warn: Theme.Warn}
+			renderer.Draw(screen, areaX, areaY, areaW, areaH, theme)
+		}
 	}
 
-	// Center: Shiba / visual area under the task
-	shibaY := centerY + taskH + pad
-	shibaH := 220
-	drawCard(screen, centerX, shibaY, centerW, shibaH)
-	// draw pixel Shiba centered in the shiba card
-	// call existing DrawEvolvingAI to render the shiba into the card area
-	DrawEvolvingAI(screen, face, centerX+8, shibaY+8, centerW-16, shibaH-16, 0, vm.CurrentLanguage, 0)
+	// 已移除獨立戰鬥區塊：進度動畫已整合於 Task 區塊
 
-	// Right: Languages panel
+	// 移除 Task 底下 Hotkeys 橫條（統一在畫面最底顯示提示）
+
+	// Right: Languages panel（延伸到底）
 	rightX := centerX + centerW + pad*2
 	rightY := leftY
-	// compute dynamic height for languages (fit content)
-	rows := len(vm.Languages)
-	langRowH := 24
-	langH := 28 + max(0, rows*langRowH) + pad
-	if langH < 120 {
-		langH = 120
+	// 右欄保證不超出視窗右側安全邊距 pad*2
+	if rxMax := sw - pad*2 - rightX; rxMax < rightW {
+		if rxMax < 0 {
+			rightW = 0
+		} else {
+			rightW = rxMax
+		}
 	}
+	baselineBottom = leftY + leftH + pad + 160 // 與左側一致
+	// 增加列高，分成三行（標題/數值/進度條）以避免擁擠
+	langRowH := 54
+	ribbonH := 28
+	langH := baselineBottom - rightY
 	drawCard(screen, rightX, rightY, rightW, langH)
 	lx, ly := rightX+pad, rightY+pad+12
-	text.Draw(screen, "Languages", face, lx, ly, Theme.TextMain)
+	drawText(screen, face, "Languages", lx, ly, Theme.TextMain)
 	ly += 16
-	order := []string{"go", "py", "js"}
-	seen := map[string]bool{}
+	// 建立語言集（確保 go/py/js 存在）
+	langs := map[string]LangHUD{}
+	for k, v := range vm.Languages {
+		langs[k] = v
+	}
+	for _, code := range []string{"go", "py", "js"} {
+		if _, ok := langs[code]; !ok {
+			langs[code] = LangHUD{Code: code}
+		}
+	}
+	// 依模式排序
+	keys := make([]string, 0, len(langs))
+	for k := range langs {
+		keys = append(keys, k)
+	}
+	mode := vm.LangSort
+	if mode == "" {
+		mode = "lv"
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		si := langs[keys[i]]
+		sj := langs[keys[j]]
+		switch mode {
+		case "k":
+			if si.Knowledge != sj.Knowledge {
+				return si.Knowledge > sj.Knowledge
+			}
+			if si.Level != sj.Level {
+				return si.Level > sj.Level
+			}
+		case "recent":
+			ti := int64(0)
+			tj := int64(0)
+			if vm.LangRecent != nil {
+				if v, ok := vm.LangRecent[keys[i]]; ok {
+					ti = v
+				}
+				if v, ok := vm.LangRecent[keys[j]]; ok {
+					tj = v
+				}
+			}
+			if ti != tj {
+				return ti > tj
+			}
+			if si.Level != sj.Level {
+				return si.Level > sj.Level
+			}
+			if si.Knowledge != sj.Knowledge {
+				return si.Knowledge > sj.Knowledge
+			}
+		default: // lv
+			if si.Level != sj.Level {
+				return si.Level > sj.Level
+			}
+			if si.Knowledge != sj.Knowledge {
+				return si.Knowledge > sj.Knowledge
+			}
+		}
+		return keys[i] < keys[j]
+	})
+	// track best next unlock
+	bestCode := ""
+	var bestRem int64 = -1
 	row := func(code string, s LangHUD) {
+		// mini-card background per language row
+		rx0 := rightX + 6
+		ry0 := ly - 14
+		rw0 := rightW - 12
+		rh0 := langRowH - 8
+		drawRoundedFilledRect(screen, rx0, ry0, rw0, rh0, 6, Theme.CardBg)
+		drawRoundedRectOutline(screen, rx0, ry0, rw0, rh0, 6, Theme.CardBorder, 1)
+		// 第一行：語言代碼與 READY
 		col := Theme.TextSub
 		if code == vm.CurrentLanguage {
 			col = Theme.Good
 		}
-		label := fmt.Sprintf("%s  K:%d  R:%d  Lv:%d", code, s.Knowledge, s.Research, s.Level)
-		text.Draw(screen, label, face, lx, ly, col)
+		titleY := ly - 2
+		drawText(screen, face, code, lx, titleY, col)
+		// READY 標示（用 badge 顯示）
+		nextCost := nextUpgradeCostForLevel(s.Level)
+		ready := s.Research >= nextCost && nextCost > 0
+		if ready {
+			// 將 READY 放在語言代碼之後，避免壓到右側 K/R/Lv
+			codeEndX := lx + textWidth(face, code)
+			badgeX := codeEndX + 8
+			badgeY := titleY - 10
+			drawBadge(screen, badgeX, badgeY, "READY", face, true)
+		}
+		// 第二行：K / R（靠左）與 Lv（靠右）
+		statsY := ly + 14
+		bx := lx
+		// K:
+		drawText(screen, face, "K:", bx, statsY, col)
+		bx += textWidth(face, "K:")
+		drawText(screen, face, fmt.Sprintf("%d", s.Knowledge), bx, statsY, color.RGBA{0x58, 0xB8, 0xFF, 0xFF})
+		bx += textWidth(face, fmt.Sprintf("%d", s.Knowledge))
+		// spacing + R:
+		drawText(screen, face, "   R:", bx, statsY, col)
+		bx += textWidth(face, "   R:")
+		drawText(screen, face, fmt.Sprintf("%d", s.Research), bx, statsY, color.RGBA{0x6B, 0xE5, 0x9C, 0xFF})
+		// Lv 右對齊
+		lvLabel := fmt.Sprintf("Lv:%d", s.Level)
+		lvW := textWidth(face, lvLabel)
+		lvX := rightX + rightW - pad - lvW
+		drawText(screen, face, lvLabel, lvX, statsY, col)
+		// 取消右上小錠片，避免壓到右側資訊
+		// upgrade glow: outline glow around the mini-card for 1s
+		if vm.Pulses != nil {
+			if until, ok := vm.Pulses[code]; ok {
+				left := time.Until(until)
+				if left > 0 {
+					pulseWindow := 1000 * time.Millisecond
+					if left > pulseWindow {
+						left = pulseWindow
+					}
+					// t in [0,1]
+					t := 1 - float32(left)/float32(pulseWindow)
+					if t < 0 {
+						t = 0
+					} else if t > 1 {
+						t = 1
+					}
+					a := uint8(140 + 100*(1-t))
+					glow := color.RGBA{R: Theme.Accent.R, G: Theme.Accent.G, B: Theme.Accent.B, A: a}
+					drawRoundedRectOutline(screen, rx0-1, ry0-1, rw0+2, rh0+2, 7, glow, 2)
+				}
+			}
+		}
+		// progress bar line (Research toward next upgrade)
+		if nextCost <= 0 {
+			nextCost = 1
+		}
+		pct := float32(0)
+		if s.Research > 0 {
+			pct = float32(s.Research) / float32(nextCost)
+			if pct > 1 {
+				pct = 1
+			}
+		}
+		barX := rx0 + 8
+		barY := ly + 28
+		barW := rightW - pad*2
+		barH := 8
+		// background track with subtle alpha
+		track := color.RGBA{R: Theme.CardBorder.R, G: Theme.CardBorder.G, B: Theme.CardBorder.B, A: 140}
+		fill := Theme.Good
+		if ready {
+			fill = Theme.Accent
+		}
+		if barW > 0 {
+			drawProgressBar(screen, barX, barY, barW, barH, pct, track, fill)
+		}
+		// 右對齊提示 "R x / y"
+		hint := fmt.Sprintf("R %d / %d", s.Research, nextCost)
+		hx := barX + barW - textWidth(face, hint)
+		hy := barY + barH - 2
+		drawText(screen, face, hint, hx, hy, Theme.TextSub)
+		// record next unlock candidate
+		if !ready {
+			rem := nextCost - s.Research
+			if rem < 0 {
+				rem = 0
+			}
+			if bestRem < 0 || rem < bestRem {
+				bestRem = rem
+				bestCode = code
+			}
+		}
 		ly += langRowH
 	}
-	for _, k := range order {
-		if s, ok := vm.Languages[k]; ok {
-			row(k, s)
-			seen[k] = true
-		}
+	// 依排序 keys 逐行畫出
+	for _, k := range keys {
+		row(k, langs[k])
 	}
-	for k, s := range vm.Languages {
-		if seen[k] {
-			continue
-		}
-		row(k, s)
+	// Next Unlock ribbon at bottom（改為復古黑底綠字螢幕風格）
+	ribX := rightX + 1
+	ribY := rightY + langH - ribbonH - 1
+	ribW := rightW - 2
+	ribH := ribbonH - 6
+	crtBg := color.RGBA{0x05, 0x08, 0x0A, 0xFF} // 近黑底
+	neon := color.RGBA{0x4D, 0xF7, 0x7A, 0xCC}  // 螢光綠邊
+	txt := color.RGBA{0x4D, 0xF7, 0x7A, 0xFF}   // 螢光綠字
+	drawRoundedFilledRect(screen, ribX+4, ribY+2, ribW-8, ribH, 6, crtBg)
+	drawRoundedRectOutline(screen, ribX+4, ribY+2, ribW-8, ribH, 6, neon, 1.2)
+	// 螢幕掃描線
+	for hy := ribY + 3; hy < ribY+2+ribH-2; hy += 3 {
+		c := color.RGBA{txt.R, txt.G, txt.B, 35}
+		vector.StrokeLine(screen, float32(ribX+6), float32(hy), float32(ribX+ribW-6), float32(hy), 1, c, true)
 	}
+	info := ""
+	if bestCode != "" && bestRem >= 0 {
+		info = fmt.Sprintf("> Next: %s +Lv (need R %d)", bestCode, bestRem)
+	} else {
+		info = "> Next: Ready to upgrade!"
+	}
+	drawText(screen, face, info, ribX+8, ribY+2+ribH/2+6, txt)
 
-	// Controls hint (bottom center)
-	controls := "Controls: P Practice | U Upgrade | C Claim | 1 Go | 2 Python | 3 JavaScript"
-	bw := text.BoundString(face, controls).Dx()
-	cx := (sw - bw) / 2
-	text.Draw(screen, controls, face, cx, sh-pad, Theme.TextSub)
+	// Bottom-left: Store panel (Servers / GPUs)
+	// layout: under Status card at left
+	storeX := leftX
+	storeY := leftY + leftH + pad
+	storeW := leftW
+	storeH := 160
+	drawCard(screen, storeX, storeY, storeW, storeH)
+	drawRoundedRectOutline(screen, storeX, storeY, storeW, storeH, Theme.Radius8, Theme.OutlineBlue, 1)
+	stx, sty := storeX+innerPad, storeY+innerPad+12
+	drawText(screen, face, "Store", stx, sty, Theme.TextMain)
+	sty += 12
+	// mini cards: Server & GPU
+	miniW := (storeW - pad*3) / 2
+	miniH := 96
+	inner := 10
+	// Server card
+	srvX := storeX + innerPad
+	srvY := sty
+	drawRoundedFilledRect(screen, srvX, srvY, miniW, miniH, 8, Theme.CardBg)
+	drawRoundedRectOutline(screen, srvX, srvY, miniW, miniH, 8, Theme.CardBorder, 1)
+	// line 1: title
+	drawText(screen, face, "Server", srvX+inner, srvY+inner+12, Theme.TextMain)
+	// line 2: owned
+	drawText(screen, face, fmt.Sprintf("Owned: %d", vm.Servers), srvX+inner, srvY+inner+12+16, Theme.TextSub)
+	// line 3: price
+	costServer := fmt.Sprintf("K %d", StoreCostServerK)
+	drawText(screen, face, "Price:", srvX+inner, srvY+inner+12+16+16, Theme.TextSub)
+	drawText(screen, face, costServer, srvX+inner+textWidth(face, "Price:")+6, srvY+inner+12+16+16, color.RGBA{0x58, 0xB8, 0xFF, 0xFF})
+	// line 4: buy button at bottom with padding
+	canS := vm.CanAffordServer()
+	btnSW := 14 + textWidth(face, "Buy")
+	btnSH := 22
+	btnSX := srvX + inner
+	btnSY := srvY + miniH - inner - btnSH
+	hoveredS := pointInRect(mx, my, btnSX, btnSY, btnSW, btnSH)
+	drawButton(screen, btnSX, btnSY, btnSW, btnSH, "Buy", face, canS, hoveredS)
+	// 記錄本幀 Server Buy 點擊矩形
+	lastServerBuyRect = uiRect{X: btnSX, Y: btnSY, W: btnSW, H: btnSH}
+	// GPU card
+	gpuX := srvX + miniW + pad
+	gpuY := sty
+	drawRoundedFilledRect(screen, gpuX, gpuY, miniW, miniH, 8, Theme.CardBg)
+	drawRoundedRectOutline(screen, gpuX, gpuY, miniW, miniH, 8, Theme.CardBorder, 1)
+	// line 1: title
+	drawText(screen, face, "GPU", gpuX+inner, gpuY+inner+12, Theme.TextMain)
+	// line 2: owned
+	drawText(screen, face, fmt.Sprintf("Owned: %d", vm.GPUs), gpuX+inner, gpuY+inner+12+16, Theme.TextSub)
+	// line 3: price
+	costGPU := fmt.Sprintf("K %d", StoreCostGPUK)
+	drawText(screen, face, "Price:", gpuX+inner, gpuY+inner+12+16+16, Theme.TextSub)
+	drawText(screen, face, costGPU, gpuX+inner+textWidth(face, "Price:")+6, gpuY+inner+12+16+16, color.RGBA{0x58, 0xB8, 0xFF, 0xFF})
+	// line 4: buy button
+	canG := vm.CanAffordGPU()
+	btnGW := 14 + textWidth(face, "Buy")
+	btnGH := 22
+	btnGX := gpuX + inner
+	btnGY := gpuY + miniH - inner - btnGH
+	hoveredG := pointInRect(mx, my, btnGX, btnGY, btnGW, btnGH)
+	drawButton(screen, btnGX, btnGY, btnGW, btnGH, "Buy", face, canG, hoveredG)
+	// 記錄本幀 GPU Buy 點擊矩形
+	lastGPUBuyRect = uiRect{X: btnGX, Y: btnGY, W: btnGW, H: btnGH}
+	// slots bar below
+	sty = sty + miniH + 8
+	drawSlotsBar(screen, stx, sty, vm.Slots, vm.GPUs, vm)
+	// no extra hint here; see bottom bar
+
+	// 底部極簡 Hotkeys（僅必要鍵，並尊重 ShowHotkeys）
+	if vm.ShowHotkeys {
+		// 幾個層級，依螢幕寬度自適應
+		full := "P Practice  T Targeted  D Deploy  R Research  U Upgrade  C Claim  1 Go  2 Py  3 JS"
+		mid := "P T D R U C  |  1 Go 2 Py 3 JS"
+		small := "P T D R U C | 1 2 3"
+		// 選擇可容納的字串
+		candidates := []string{full, mid, small}
+		chosen := small
+		for _, s := range candidates {
+			if textWidth(face, s) <= sw-Theme.Pad8*2 {
+				chosen = s
+				break
+			}
+		}
+		bw := textWidth(face, chosen)
+		cx := (sw - bw) / 2
+		drawText(screen, face, chosen, cx, sh-Theme.Pad8, Theme.TextSub)
+	}
 }
 
 // VM 是繪圖所需的最小視圖（由 State 快照轉換而來）。
@@ -182,6 +610,39 @@ type VM struct {
 	// Multi-language 額外資訊（用於左側語言卡片）
 	CurrentLanguage string
 	Languages       map[string]LangHUD
+	// Pulses 短暫脈動效果：語言代碼 -> 截止時間（在此之前顯示一圈擴散環）
+	Pulses map[string]time.Time
+	// 戰鬥動畫：任務成功/失敗的短暫呈現
+	BattleType  string
+	BattleUntil time.Time
+	BattleLang  string
+	BattleStyle int
+	// Store
+	Servers int
+	GPUs    int
+	Slots   int
+	// Animations (ephemeral, provided by App)
+	KBounceStart    time.Time
+	KBounceUntil    time.Time
+	RBounceStart    time.Time
+	RBounceUntil    time.Time
+	KFloatText      string
+	KFloatStart     time.Time
+	KFloatUntil     time.Time
+	RFloatText      string
+	RFloatStart     time.Time
+	RFloatUntil     time.Time
+	GPUAnimStart    time.Time
+	GPUAnimUntil    time.Time
+	ServerAnimStart time.Time
+	ServerAnimUntil time.Time
+	// UI toggles
+	ShowHotkeys bool
+	// 語言排序與最近使用
+	LangSort   string
+	LangRecent map[string]int64 // 語言 -> 最近使用（unix 秒）
+	// 本地任務視覺預覽（不影響後端）："deploy" | "research" | ""（空=依照後端）
+	TaskPreview string
 }
 
 type VMTask struct {
@@ -203,26 +664,18 @@ type LangHUD struct {
 // --- styled helpers ---
 
 func drawCard(dst *ebiten.Image, x, y, w, h int) {
-	// 陰影（輕微）
-	shadow := color.RGBA{0, 0, 0, 36}
-	drawRoundedFilledRect(dst, x+2, y+3, w, h, Theme.Radius8, shadow)
-	// 本體
 	drawRoundedFilledRect(dst, x, y, w, h, Theme.Radius8, Theme.CardBg)
-	// 外框（圍繞圓角邊）
-	drawRoundedRectOutline(dst, x, y, w, h, Theme.Radius8, Theme.CardBorder, 1)
 }
 
 func drawBadge(dst *ebiten.Image, x, y int, textStr string, face font.Face, ok bool) {
 	padX, padY := 6, 4
-	b := text.BoundString(face, textStr)
-	w := padX*2 + b.Dx()
+	w := padX*2 + textWidth(face, textStr)
 	h := padY*2 + 14
 	// 背景色：可負擔用 Good，不可負擔用 Warn，並做小幅脈動（提示不足）
 	var bg color.RGBA
 	if ok {
 		bg = Theme.Good
 	} else {
-		// 以 1.2 秒週期讓 alpha 在 180~255 摆動
 		period := float64(1200 * time.Millisecond)
 		t := float64(time.Now().UnixNano()%int64(period)) / period
 		a := uint8(180 + 75*0.5*(1+math.Sin(2*math.Pi*t)))
@@ -230,49 +683,91 @@ func drawBadge(dst *ebiten.Image, x, y int, textStr string, face font.Face, ok b
 	}
 	drawRoundedFilledRect(dst, x, y, w, h, 6, Theme.CardBorder)
 	drawRoundedFilledRect(dst, x+1, y+1, w-2, h-2, 5, bg)
-	text.Draw(dst, textStr, face, x+padX, y+padY+12, color.Black)
+	drawText(dst, face, textStr, x+padX, y+padY+12, color.RGBA{0, 0, 0, 255})
 }
 
-func drawArcRing(dst *ebiten.Image, cx, cy, r int, ratio float32, colStart, colEnd color.RGBA) {
-	// 背景環
-	vector.StrokeCircle(dst, float32(cx), float32(cy), float32(r), 2, Theme.CardBorder, true)
-	// 前景弧：以多段近似連續弧形
-	if ratio <= 0 {
-		return
-	}
-	if ratio > 1 {
-		ratio = 1
-	}
-	seg := 120
-	end := int(float32(seg) * ratio)
-	var prevX, prevY float32
-	for i := 0; i <= end; i++ {
-		ang := -math.Pi/2 + 2*math.Pi*float64(i)/float64(seg)
-		x := float32(cx) + float32(r)*float32(math.Cos(ang))
-		y := float32(cy) + float32(r)*float32(math.Sin(ang))
-		if i > 0 {
-			t := float32(i) / float32(max(1, end))
-			col := lerpRGBA(colStart, colEnd, t)
-			vector.StrokeLine(dst, prevX, prevY, x, y, 3, col, true)
-		}
-		prevX, prevY = x, y
-	}
-}
+// --- small helpers for animations ---
 
-func lerpRGBA(a, b color.RGBA, t float32) color.RGBA {
+func timeProgress(start, until time.Time) float32 {
+	if start.IsZero() || until.IsZero() {
+		return 0
+	}
+	now := time.Now()
+	if now.After(until) {
+		return 1
+	}
+	total := until.Sub(start).Seconds()
+	if total <= 0 {
+		return 1
+	}
+	t := now.Sub(start).Seconds() / total
 	if t < 0 {
 		t = 0
-	} else if t > 1 {
+	}
+	if t > 1 {
 		t = 1
 	}
-	lerp := func(x, y uint8) uint8 { return uint8(float32(x) + (float32(y)-float32(x))*t + 0.5) }
-	return color.RGBA{
-		R: lerp(a.R, b.R),
-		G: lerp(a.G, b.G),
-		B: lerp(a.B, b.B),
-		A: lerp(a.A, b.A),
+	return float32(t)
+}
+
+// bounceYOffset returns a small negative y offset (upwards) with ease-out sinus curve.
+func bounceYOffset(start, until time.Time, amp int) int {
+	if start.IsZero() || until.IsZero() {
+		return 0
+	}
+	t := timeProgress(start, until)
+	// use a single up-down arc: y = -sin(t*pi) * amp
+	off := -math.Sin(float64(t)*math.Pi) * float64(amp)
+	return int(off)
+}
+
+// drawSlotsBar draws slot frames and filled GPUs; uses vm GPU/Server animations to render effects.
+func drawSlotsBar(dst *ebiten.Image, x, y int, slots int, gpus int, vm VM) {
+	if slots <= 0 {
+		return
+	}
+	gap := 6
+	w, h := 12, 10
+	// pulse glow when server just added
+	pulse := false
+	if !vm.ServerAnimStart.IsZero() && time.Now().Before(vm.ServerAnimUntil) {
+		pulse = true
+	}
+	for i := 0; i < slots; i++ {
+		sx := x + i*(w+gap)
+		sy := y
+		border := Theme.CardBorder
+		if pulse {
+			// subtle glow
+			t := timeProgress(vm.ServerAnimStart, vm.ServerAnimUntil)
+			a := uint8(120 + 80*(1-t))
+			border = color.RGBA{R: Theme.OutlineBlue.R, G: Theme.OutlineBlue.G, B: Theme.OutlineBlue.B, A: a}
+		}
+		drawRoundedRectOutline(dst, sx, sy, w, h, 2, border, 1)
+		if i < gpus {
+			drawRoundedFilledRect(dst, sx+1, sy+1, w-2, h-2, 1.5, Theme.Good)
+		}
+	}
+	// GPU insert animation: slide a GPU into the last filled slot
+	if gpus > 0 && !vm.GPUAnimStart.IsZero() && time.Now().Before(vm.GPUAnimUntil) {
+		t := timeProgress(vm.GPUAnimStart, vm.GPUAnimUntil)
+		idx := gpus - 1
+		if idx >= slots {
+			idx = slots - 1
+		}
+		sx := x + idx*(w+gap)
+		sy := y
+		// start above and slide down
+		yy := float32(sy - 14 + int(14*t))
+		drawRoundedFilledRect(dst, sx+1, int(yy)+1, w-2, h-2, 1.5, Theme.Good)
+		// small glow at the end
+		glowA := uint8(200 * (1 - t))
+		glow := color.RGBA{R: Theme.Good.R, G: Theme.Good.G, B: Theme.Good.B, A: glowA}
+		vector.StrokeRect(dst, float32(sx), float32(sy), float32(w), float32(h), 2, glow, true)
 	}
 }
+
+// 移除圓角弧環與內插相關輔助（目前未使用）
 
 func max(a, b int) int {
 	if a > b {
@@ -283,58 +778,192 @@ func max(a, b int) int {
 
 // --- rounded rect helpers ---
 
-func drawRoundedFilledRect(dst *ebiten.Image, x, y, w, h int, radius float32, col color.Color) {
+func drawRoundedFilledRect(dst *ebiten.Image, x, y, w, h int, _ float32, col color.Color) {
+	// 改為純方角填滿，移除四角圓圈
 	if w <= 0 || h <= 0 {
 		return
 	}
-	r := radius
-	if r < 0 {
-		r = 0
-	}
-	if float32(w) < 2*r {
-		r = float32(w) / 2
-	}
-	if float32(h) < 2*r {
-		r = float32(h) / 2
-	}
-	// 中央長方形
-	vector.DrawFilledRect(dst, float32(x)+r, float32(y), float32(w)-2*r, float32(h), col, true)
-	// 左右直條
-	vector.DrawFilledRect(dst, float32(x), float32(y)+r, r, float32(h)-2*r, col, true)
-	vector.DrawFilledRect(dst, float32(x)+float32(w)-r, float32(y)+r, r, float32(h)-2*r, col, true)
-	// 四角圓
-	vector.DrawFilledCircle(dst, float32(x)+r, float32(y)+r, r, col, true)
-	vector.DrawFilledCircle(dst, float32(x)+float32(w)-r, float32(y)+r, r, col, true)
-	vector.DrawFilledCircle(dst, float32(x)+r, float32(y)+float32(h)-r, r, col, true)
-	vector.DrawFilledCircle(dst, float32(x)+float32(w)-r, float32(y)+float32(h)-r, r, col, true)
+	vector.DrawFilledRect(dst, float32(x), float32(y), float32(w), float32(h), col, true)
 }
 
-func drawRoundedRectOutline(dst *ebiten.Image, x, y, w, h int, radius float32, col color.Color, width float32) {
+func drawRoundedRectOutline(dst *ebiten.Image, x, y, w, h int, _ float32, col color.Color, width float32) {
+	// 改為純方角外框，移除四角圓圈
 	if w <= 0 || h <= 0 {
 		return
 	}
-	r := radius
-	if r < 0 {
-		r = 0
-	}
-	if float32(w) < 2*r {
-		r = float32(w) / 2
-	}
-	if float32(h) < 2*r {
-		r = float32(h) / 2
-	}
-	// 邊緣線（四邊）
-	vector.StrokeLine(dst, float32(x)+r, float32(y), float32(x)+float32(w)-r, float32(y), width, col, true)
-	vector.StrokeLine(dst, float32(x)+float32(w), float32(y)+r, float32(x)+float32(w), float32(y)+float32(h)-r, width, col, true)
-	vector.StrokeLine(dst, float32(x)+r, float32(y)+float32(h), float32(x)+float32(w)-r, float32(y)+float32(h), width, col, true)
-	vector.StrokeLine(dst, float32(x), float32(y)+r, float32(x), float32(y)+float32(h)-r, width, col, true)
-	// 四角圓弧（以 StrokeCircle 畫整圓，視覺上可接受）
-	vector.StrokeCircle(dst, float32(x)+r, float32(y)+r, r, width, col, true)
-	vector.StrokeCircle(dst, float32(x)+float32(w)-r, float32(y)+r, r, width, col, true)
-	vector.StrokeCircle(dst, float32(x)+r, float32(y)+float32(h)-r, r, width, col, true)
-	vector.StrokeCircle(dst, float32(x)+float32(w)-r, float32(y)+float32(h)-r, r, width, col, true)
+	vector.StrokeRect(dst, float32(x), float32(y), float32(w), float32(h), width, col, true)
 }
 
 func canAfford(vm VM) bool {
 	return vm.Research >= vm.NextUpgradeCost
 }
+
+// drawText 是 text/v2 的薄封裝，提供舊介面形式的呼叫方式。
+func drawText(dst *ebiten.Image, face font.Face, s string, x, y int, col color.RGBA) {
+	xf := text.NewGoXFace(face)
+	m := xf.Metrics()
+	// 模擬 v1：以 (x,y) 為 baseline，將繪製區塊往上移動 HAscent
+	var op text.DrawOptions
+	op.GeoM.Translate(float64(x), float64(y)-m.HAscent)
+	op.ColorScale.ScaleWithColor(col)
+	text.Draw(dst, s, xf, &op)
+}
+
+// drawTextScaled draws text with a scale factor and correct baseline.
+func drawTextScaled(dst *ebiten.Image, face font.Face, s string, x, y int, col color.RGBA, scale float64) {
+	if scale <= 0 {
+		scale = 1
+	}
+	xf := text.NewGoXFace(face)
+	m := xf.Metrics()
+	var op text.DrawOptions
+	op.GeoM.Scale(scale, scale)
+	// translate after scale: baseline at y - HAscent*scale
+	op.GeoM.Translate(float64(x), float64(y)-m.HAscent*scale)
+	op.ColorScale.ScaleWithColor(col)
+	text.Draw(dst, s, xf, &op)
+}
+
+// textWidth 使用 text/v2 測量文字寬度（像素，向上取整）。
+func textWidth(face font.Face, s string) int {
+	if s == "" || face == nil {
+		return 0
+	}
+	xf := text.NewGoXFace(face)
+	w, _ := text.Measure(s, xf, 0)
+	return int(math.Ceil(w))
+}
+
+// --- Store 常數（與後端同步）：成本（Knowledge）
+const (
+	StoreCostServerK = 150
+	StoreCostGPUK    = 80
+	// 顯卡對研究產率的固定加成（顯示用途；後端目前為 +1 R/min/顯卡）
+	GPUBonusRPM = 1
+)
+
+// 推導可負擔（純前端估計，不作為實際判定）：
+func (vm VM) CanAffordServer() bool { return vm.Knowledge >= StoreCostServerK }
+
+// GPU 還需插槽可用
+func (vm VM) CanAffordGPU() bool {
+	if vm.Knowledge < StoreCostGPUK {
+		return false
+	}
+	return vm.GPUs < vm.Slots
+}
+
+// drawBlueprintGrid renders a subtle moving grid background.
+func drawBlueprintGrid(dst *ebiten.Image, x, y, w, h int) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	step := 12
+	// slight horizontal animation based on time
+	t := float32(time.Now().UnixNano()%1_000_000_000) / 1_000_000_000
+	off := int(float32(step) * (t * 0.5)) // slow drift
+	gridCol := color.RGBA{R: Theme.CardBorder.R, G: Theme.CardBorder.G, B: Theme.CardBorder.B, A: 60}
+	// vertical lines
+	for vx := x + off; vx < x+w; vx += step {
+		vector.StrokeLine(dst, float32(vx), float32(y), float32(vx), float32(y+h), 1, gridCol, true)
+	}
+	// horizontal lines
+	for hy := y + off; hy < y+h; hy += step {
+		vector.StrokeLine(dst, float32(x), float32(hy), float32(x+w), float32(hy), 1, gridCol, true)
+	}
+}
+
+// drawPillChip：已取消晶片樣式（保留註解位置給未來擴充）。
+
+// nextUpgradeCostForLevel replicates the server's cost formula for display: 100 * 2^level.
+func nextUpgradeCostForLevel(level int) int64 {
+	cost := int64(100)
+	for i := 0; i < level; i++ {
+		cost *= 2
+	}
+	return cost
+}
+
+// drawProgressBar draws a simple progress bar with a track and a filled portion.
+func drawProgressBar(dst *ebiten.Image, x, y, w, h int, pct float32, track color.RGBA, fill color.RGBA) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 1 {
+		pct = 1
+	}
+	// track
+	drawRoundedFilledRect(dst, x, y, w, h, 4, track)
+	// fill
+	fw := int(float32(w) * pct)
+	if fw > 0 {
+		drawRoundedFilledRect(dst, x, y, fw, h, 4, fill)
+	}
+}
+
+// --- button helpers ---
+
+// pointInRect returns whether (mx,my) is inside rect x,y,w,h
+func pointInRect(mx, my, x, y, w, h int) bool {
+	return mx >= x && my >= y && mx < x+w && my < y+h
+}
+
+// drawButton draws a pill-like button with hover and disabled states.
+// When disabled, it draws a lock icon and grays out the content.
+func drawButton(dst *ebiten.Image, x, y, w, h int, label string, face font.Face, enabled bool, hovered bool) {
+	if w <= 0 || h <= 0 {
+		return
+	}
+	radius := float32(h) / 2
+	// base colors
+	var bg color.RGBA
+	fg := Theme.TextMain
+	var border color.RGBA
+	if enabled {
+		bg = color.RGBA{R: Theme.Accent.R, G: Theme.Accent.G, B: Theme.Accent.B, A: 40}
+		border = color.RGBA{R: Theme.Accent.R, G: Theme.Accent.G, B: Theme.Accent.B, A: 150}
+	} else {
+		// 灰階
+		g := color.RGBA{0x7A, 0x86, 0x99, 0xFF}
+		bg = color.RGBA{R: g.R, G: g.G, B: g.B, A: 40}
+		border = g
+		fg = color.RGBA{0xBD, 0xC7, 0xD4, 0xFF}
+	}
+	// 按下效果：縮小 1px 邊距（僅視覺，簡單版）
+	if enabled && hovered && ebiten.IsMouseButtonPressed(ebiten.MouseButtonLeft) {
+		x += 1
+		y += 1
+		w -= 2
+		h -= 2
+	}
+	// draw body
+	drawRoundedFilledRect(dst, x, y, w, h, radius, bg)
+	drawRoundedRectOutline(dst, x, y, w, h, radius, border, 1)
+	// glow on hover when enabled
+	if enabled && hovered {
+		// 改為矩形外框高光，避免角落圓圈效果
+		glow := color.RGBA{R: Theme.OutlineBlue.R, G: Theme.OutlineBlue.G, B: Theme.OutlineBlue.B, A: 200}
+		vector.StrokeRect(dst, float32(x), float32(y), float32(w), float32(h), 2, glow, true)
+	}
+	// label
+	tx := x + (w-textWidth(face, label))/2
+	ty := y + h/2 + 6
+	drawText(dst, face, label, tx, ty, fg)
+	// disabled lock icon
+	if !enabled {
+		// small lock at left side of the label
+		lx := x + 6
+		ly := y + h/2 - 6
+		lockCol := border
+		// shackle (arc-like using circles/lines)
+		vector.StrokeCircle(dst, float32(lx+6), float32(ly+6), 6, 2, lockCol, true)
+		vector.DrawFilledRect(dst, float32(lx), float32(ly+6), 12, 10, lockCol, true)
+		keyhole := color.RGBA{0, 0, 0, 180}
+		vector.DrawFilledCircle(dst, float32(lx+6), float32(ly+11), 1.5, keyhole, true)
+	}
+}
+
+// （保留位置給未來 mini-game 形狀輔助）

--- a/client/internal/ui/theme.go
+++ b/client/internal/ui/theme.go
@@ -4,15 +4,16 @@ import "image/color"
 
 // Theme：Phase 0.5 的色票與間距常數
 var Theme = struct {
-	Bg         color.RGBA
-	CardBg     color.RGBA
-	CardBorder color.RGBA
-	TextMain   color.RGBA
-	TextSub    color.RGBA
-	Accent     color.RGBA
-	Warn       color.RGBA
-	Error      color.RGBA
-	Good       color.RGBA
+	Bg          color.RGBA
+	CardBg      color.RGBA
+	CardBorder  color.RGBA
+	OutlineBlue color.RGBA
+	TextMain    color.RGBA
+	TextSub     color.RGBA
+	Accent      color.RGBA
+	Warn        color.RGBA
+	Error       color.RGBA
+	Good        color.RGBA
 
 	Pad8    int
 	Radius8 float32
@@ -20,12 +21,14 @@ var Theme = struct {
 	Bg:         color.RGBA{0x0B, 0x0E, 0x14, 0xFF},
 	CardBg:     color.RGBA{0x14, 0x19, 0x22, 0xE6},
 	CardBorder: color.RGBA{0x23, 0x2B, 0x3A, 0xFF},
-	TextMain:   color.RGBA{0xE6, 0xED, 0xF3, 0xFF},
-	TextSub:    color.RGBA{0x94, 0xA3, 0xB8, 0xFF},
-	Accent:     color.RGBA{0x3D, 0xA9, 0xFC, 0xFF},
-	Warn:       color.RGBA{0xF5, 0x9E, 0x0B, 0xFF},
-	Error:      color.RGBA{0xF4, 0x3F, 0x5E, 0xFF},
-	Good:       color.RGBA{0x5E, 0xEA, 0xD4, 0xFF},
+	// 淡藍色描邊（比 Accent 柔和一些）
+	OutlineBlue: color.RGBA{0x58, 0xB8, 0xFF, 0xCC},
+	TextMain:    color.RGBA{0xE6, 0xED, 0xF3, 0xFF},
+	TextSub:     color.RGBA{0x94, 0xA3, 0xB8, 0xFF},
+	Accent:      color.RGBA{0x3D, 0xA9, 0xFC, 0xFF},
+	Warn:        color.RGBA{0xF5, 0x9E, 0x0B, 0xFF},
+	Error:       color.RGBA{0xF4, 0x3F, 0x5E, 0xFF},
+	Good:        color.RGBA{0x5E, 0xEA, 0xD4, 0xFF},
 
 	Pad8:    8,
 	Radius8: 8,

--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,14 @@ require (
 	github.com/ebitengine/gomobile v0.0.0-20240911145611-4856209ac325 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
 	github.com/ebitengine/purego v0.8.0 // indirect
+	github.com/go-text/typesetting v0.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/dig v1.16.1 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj
 github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
 github.com/ebitengine/purego v0.8.0 h1:JbqvnEzRvPpxhCJzJJ2y0RbiZ8nyjccVUrSM3q+GvvE=
 github.com/ebitengine/purego v0.8.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/go-text/typesetting v0.2.0 h1:fbzsgbmk04KiWtE+c3ZD4W2nmCRzBqrqQOvYlwAOdho=
+github.com/go-text/typesetting v0.2.0/go.mod h1:2+owI/sxa73XA581LAzVuEBZ3WEEV2pXeDswCH/3i1I=
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0 h1:0DISQM/rseKIJhdF29AkhvdzIULqNIIlXAGWit4ez1Q=
 github.com/hajimehoshi/bitmapfont/v3 v3.2.0/go.mod h1:8gLqGatKVu0pwcNCJguW3Igg9WQqVXF0zg/RvrGQWyg=
 github.com/hajimehoshi/ebiten/v2 v2.8.8 h1:xyMxOAn52T1tQ+j3vdieZ7auDBOXmvjUprSrxaIbsi8=
@@ -52,6 +54,8 @@ golang.org/x/image v0.30.0 h1:jD5RhkmVAnjqaCUXfbGBrn3lpxbknfN9w2UhHHU+5B4=
 golang.org/x/image v0.30.0/go.mod h1:SAEUTxCCMWSrJcCy/4HwavEsfZZJlYxeHLc6tTiAe/c=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=


### PR DESCRIPTION
這個 PR 包含以下重點變更：

授權與文件
- 新增 LICENSE (MIT)
- README 新增 License 與 Disclaimer（包含兩行英文聲明）

後端與用例
- 新增任務型別：Deploy、Research（app/domain/task）
- player：加入 StartDeploy/StartResearch，含研究加成的時長/獎勵計算
- usecase interactor 與 port 介面新增 StartDeploy/StartResearch
- HTTP handler 與 router 加入 /api/v1/game/start-deploy、/start-research（保留 legacy 路徑）
- viewmodel 補充欄位以支援新任務

Client API 與 UI
- client API：新增 PostStartDeploy/PostStartResearch
- HUD：導入 Renderer 介面並實作 Practice/Deploy/Research 三種視覺化
- Deploy：佇列→工作者→完成區塊隨進度變化
- Research：管線階段填充 + GC 波形掃描 + 取樣密度隨進度成長
- Practice：節奏與訊息密度微調，移除圓形倒數與迷你遊戲
- 右側語言面板與商店小卡持續優化；全域改為方形樣式、移除圓角光暈
- 底部熱鍵（Hotkeys）最小化回歸，依寬度自適應

UX 與互動
- D/R 鍵：若任務進行中則佇列 intent，完成後自動啟動；空閒時立即開始
- Y：本地預覽循環 practice→deploy→research→off
- 排序鍵位：移除 R；保留 F/V/K
- 修正初始繪製座標 bug，調整底部繪製位置

影響與注意事項
- 僅影響本地 UI 與遊戲流程；相容性不破壞
- 建議重新啟動 client 以套用新 UI 與互動
