### PR TITLE
refactor(ddd): 修正 Task 序列化 bug 並強化 DDD 架構設計

### DIFF
--- a/app/adapter/in/httpserver/game/handler.go
+++ b/app/adapter/in/httpserver/game/handler.go
@@ -2,12 +2,13 @@ package game
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
 	"go.uber.org/zap"
 
-	"go-ddd-architecture/app/domain/gametime"
+	"go-ddd-architecture/app/domain/player"
 	dto "go-ddd-architecture/app/usecase/dto/game"
 	inPort "go-ddd-architecture/app/usecase/port/in/game"
 )
@@ -29,8 +30,8 @@ type claimReq struct {
 }
 
 type claimResp struct {
-	Result    gametime.OfflineResult `json:"result"`
-	ViewModel dto.ViewModelDto       `json:"viewModel"`
+	Result    dto.OfflineResultDto `json:"result"`
+	ViewModel dto.ViewModelDto     `json:"viewModel"`
 }
 
 func (h *Handler) PostClaimOffline(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +61,7 @@ func (h *Handler) PostClaimOffline(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) PostStartPractice(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	if err := h.uc.StartPractice(now); err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		writeTaskError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
@@ -70,7 +71,7 @@ func (h *Handler) PostStartPractice(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) PostStartTargeted(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	if err := h.uc.StartTargeted(now); err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		writeTaskError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
@@ -80,7 +81,7 @@ func (h *Handler) PostStartTargeted(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) PostStartDeploy(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	if err := h.uc.StartDeploy(now); err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		writeTaskError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
@@ -90,10 +91,19 @@ func (h *Handler) PostStartDeploy(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) PostStartResearch(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().UTC()
 	if err := h.uc.StartResearch(now); err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		writeTaskError(w, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
+}
+
+// writeTaskError 將任務相關的 domain error 映射成合適的 HTTP 狀態碼。
+func writeTaskError(w http.ResponseWriter, err error) {
+	if errors.Is(err, player.ErrTaskAlreadyActive) {
+		writeError(w, http.StatusConflict, "task_already_active", err.Error())
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "internal", err.Error())
 }
 
 // Try to finish current task
@@ -134,29 +144,32 @@ func (h *Handler) PostSelectLanguage(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
 }
 
-// Buy a server (consumes Knowledge; adds GPU slots)
-type buyResp struct {
-	OK        bool             `json:"ok"`
-	ViewModel dto.ViewModelDto `json:"viewModel"`
-}
-
 func (h *Handler) PostBuyServer(w http.ResponseWriter, r *http.Request) {
-	ok, err := h.uc.BuyServer()
-	if err != nil {
+	if err := h.uc.BuyServer(); err != nil {
+		if errors.Is(err, player.ErrInsufficientKnowledge) {
+			writeError(w, http.StatusBadRequest, "not_enough_knowledge", err.Error())
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, buyResp{OK: ok, ViewModel: h.uc.GetViewModel()})
+	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
 }
 
 // Buy a GPU (consumes Knowledge; requires free slot)
 func (h *Handler) PostBuyGPU(w http.ResponseWriter, r *http.Request) {
-	ok, err := h.uc.BuyGPU()
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", err.Error())
+	if err := h.uc.BuyGPU(); err != nil {
+		switch {
+		case errors.Is(err, player.ErrNoSlotAvailable):
+			writeError(w, http.StatusBadRequest, "no_slot_available", err.Error())
+		case errors.Is(err, player.ErrInsufficientKnowledge):
+			writeError(w, http.StatusBadRequest, "not_enough_knowledge", err.Error())
+		default:
+			writeError(w, http.StatusInternalServerError, "internal", err.Error())
+		}
 		return
 	}
-	writeJSON(w, http.StatusOK, buyResp{OK: ok, ViewModel: h.uc.GetViewModel()})
+	writeJSON(w, http.StatusOK, h.uc.GetViewModel())
 }
 
 // --- shared helpers (local to game module) ---

--- a/app/adapter/in/httpserver/game/upgrade.go
+++ b/app/adapter/in/httpserver/game/upgrade.go
@@ -1,17 +1,19 @@
 package game
 
 import (
+	"errors"
 	"net/http"
+
+	"go-ddd-architecture/app/domain/player"
 )
 
 func (h *Handler) PostUpgradeKnowledge(w http.ResponseWriter, r *http.Request) {
-	ok, err := h.uc.UpgradeKnowledge()
-	if err != nil {
+	if err := h.uc.UpgradeKnowledge(); err != nil {
+		if errors.Is(err, player.ErrInsufficientResearch) {
+			writeError(w, http.StatusBadRequest, "not_enough_research", err.Error())
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "internal", err.Error())
-		return
-	}
-	if !ok {
-		writeError(w, http.StatusBadRequest, "not_enough_research", "not enough research to upgrade")
 		return
 	}
 	writeJSON(w, http.StatusOK, h.uc.GetViewModel())

--- a/app/domain/player/errors.go
+++ b/app/domain/player/errors.go
@@ -1,0 +1,18 @@
+package player
+
+import "errors"
+
+// Domain errors — 呼叫端可用 errors.Is() 判斷業務規則違反原因。
+var (
+	// ErrTaskAlreadyActive 當玩家已有進行中的任務時嘗試啟動新任務。
+	ErrTaskAlreadyActive = errors.New("a task is already in progress")
+
+	// ErrInsufficientResearch 研究點不足以執行升級。
+	ErrInsufficientResearch = errors.New("not enough research to upgrade")
+
+	// ErrInsufficientKnowledge 知識點不足以購買物品。
+	ErrInsufficientKnowledge = errors.New("not enough knowledge")
+
+	// ErrNoSlotAvailable 沒有可用的 GPU 插槽。
+	ErrNoSlotAvailable = errors.New("no GPU slot available; buy a server first")
+)

--- a/app/domain/player/player.go
+++ b/app/domain/player/player.go
@@ -51,15 +51,12 @@ func (p *Player) ApplyOfflineGains(knowledge, research int64, now time.Time) {
 }
 
 // StartPractice 啟動一個固定設定的練習任務（MVP）。
-func (p *Player) StartPractice(now time.Time) {
+// 若已有進行中的任務，回傳 ErrTaskAlreadyActive。
+func (p *Player) StartPractice(now time.Time) error {
 	if p.Current != nil && p.Current.IsActive() {
-		return
+		return ErrTaskAlreadyActive
 	}
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go" // 預設一個語言，避免空值
-		p.CurrentLanguage = lang
-	}
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	// 以研究點數縮短任務時間：最高 30% 縮短（研究達 1000 時達到上限）
 	base := 5 * time.Second
@@ -70,18 +67,16 @@ func (p *Player) StartPractice(now time.Time) {
 	t := &task.Task{ID: "practice-5s", Type: task.Practice, Language: lang, Duration: dur, BaseReward: reward}
 	t.Start(now)
 	p.Current = t
+	return nil
 }
 
 // StartTargeted 啟動一個針對當前語言的目標任務：略短時長、略高獎勵。
-func (p *Player) StartTargeted(now time.Time) {
+// 若已有進行中的任務，回傳 ErrTaskAlreadyActive。
+func (p *Player) StartTargeted(now time.Time) error {
 	if p.Current != nil && p.Current.IsActive() {
-		return
+		return ErrTaskAlreadyActive
 	}
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go"
-		p.CurrentLanguage = lang
-	}
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	// 以研究點數縮短任務時間：上限 40% 縮短（比 Practice 略高）
 	base := 4 * time.Second
@@ -92,18 +87,16 @@ func (p *Player) StartTargeted(now time.Time) {
 	t := &task.Task{ID: "targeted-4s", Type: task.Targeted, Language: lang, Duration: dur, BaseReward: reward}
 	t.Start(now)
 	p.Current = t
+	return nil
 }
 
 // StartDeploy 啟動部署任務：中等時長、較高知識獎勵。
-func (p *Player) StartDeploy(now time.Time) {
+// 若已有進行中的任務，回傳 ErrTaskAlreadyActive。
+func (p *Player) StartDeploy(now time.Time) error {
 	if p.Current != nil && p.Current.IsActive() {
-		return
+		return ErrTaskAlreadyActive
 	}
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go"
-		p.CurrentLanguage = lang
-	}
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	// 部署：基礎 5s，最高 35% 縮短（研究達 1100）
 	base := 5 * time.Second
@@ -113,18 +106,16 @@ func (p *Player) StartDeploy(now time.Time) {
 	t := &task.Task{ID: "deploy-5s", Type: task.Deploy, Language: lang, Duration: dur, BaseReward: reward}
 	t.Start(now)
 	p.Current = t
+	return nil
 }
 
 // StartResearch 啟動研究任務：時長略長、知識獎勵較溫和（研究獎勵沿用既有邏輯）。
-func (p *Player) StartResearch(now time.Time) {
+// 若已有進行中的任務，回傳 ErrTaskAlreadyActive。
+func (p *Player) StartResearch(now time.Time) error {
 	if p.Current != nil && p.Current.IsActive() {
-		return
+		return ErrTaskAlreadyActive
 	}
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go"
-		p.CurrentLanguage = lang
-	}
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	// 研究：基礎 6s，最高 45% 縮短（研究達 1400）
 	base := 6 * time.Second
@@ -134,6 +125,7 @@ func (p *Player) StartResearch(now time.Time) {
 	t := &task.Task{ID: "research-6s", Type: task.Research, Language: lang, Duration: dur, BaseReward: reward}
 	t.Start(now)
 	p.Current = t
+	return nil
 }
 
 // TryFinish 嘗試完成當前任務，若完成則結算獎勵。
@@ -234,22 +226,18 @@ func (p *Player) NextUpgradeCost() int64 {
 }
 
 // UpgradeKnowledge 嘗試進行升級：扣除當前語言的研究點，Level+1（各語言獨立）。
-func (p *Player) UpgradeKnowledge() bool {
+// 研究點不足時回傳 ErrInsufficientResearch。
+func (p *Player) UpgradeKnowledge() error {
 	cost := p.NextUpgradeCost()
-	// 從當前語言的研究點扣款（並維持全域相容：同步扣全域錢包）。
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go"
-		p.CurrentLanguage = lang
-	}
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	if s.Research < cost {
-		return false
+		return ErrInsufficientResearch
 	}
 	s.Research -= cost
 	s.Level++
 	p.Skills[lang] = s
-	return true
+	return nil
 }
 
 // SelectLanguage 設定當前語言；若尚未存在則初始化技能。
@@ -259,6 +247,19 @@ func (p *Player) SelectLanguage(lang string) {
 	}
 	_ = p.ensureSkill(lang)
 	p.CurrentLanguage = lang
+}
+
+// defaultLanguage 是當玩家尚未選擇語言時的預設值。
+const defaultLanguage = "go"
+
+// activeLang 回傳當前語言；若未設定則初始化為 defaultLanguage。
+// 這是所有需要「當前語言」操作的單一入口，避免重複的 guard clause。
+func (p *Player) activeLang() string {
+	if p.CurrentLanguage == "" {
+		p.CurrentLanguage = defaultLanguage
+		_ = p.ensureSkill(p.CurrentLanguage)
+	}
+	return p.CurrentLanguage
 }
 
 func (p *Player) ensureSkill(lang string) Skill {
@@ -297,43 +298,34 @@ const (
 )
 
 // BuyServer 嘗試購買一台伺服器主機（消耗當前語言的 Knowledge）。
-func (p *Player) BuyServer() bool {
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go"
-		p.CurrentLanguage = lang
-	}
+// 知識點不足時回傳 ErrInsufficientKnowledge。
+func (p *Player) BuyServer() error {
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	if s.Knowledge < ServerCostK {
-		return false
+		return ErrInsufficientKnowledge
 	}
 	s.Knowledge -= ServerCostK
 	p.Skills[lang] = s
 	p.Servers++
-	return true
+	return nil
 }
 
 // BuyGPU 嘗試購買一張顯卡（需有可用插槽，並消耗 Knowledge）。
-func (p *Player) BuyGPU() bool {
+// 無插槽時回傳 ErrNoSlotAvailable；知識點不足時回傳 ErrInsufficientKnowledge。
+func (p *Player) BuyGPU() error {
 	// 容量限制：需先有伺服器以提供插槽
-	cap := p.Servers * SlotsPerServer
-	if cap <= 0 {
-		return false
+	slots := p.Servers * SlotsPerServer
+	if slots <= 0 || p.GPUs >= slots {
+		return ErrNoSlotAvailable
 	}
-	if p.GPUs >= cap {
-		return false
-	}
-	lang := p.CurrentLanguage
-	if lang == "" {
-		lang = "go"
-		p.CurrentLanguage = lang
-	}
+	lang := p.activeLang()
 	s := p.ensureSkill(lang)
 	if s.Knowledge < GPUCostK {
-		return false
+		return ErrInsufficientKnowledge
 	}
 	s.Knowledge -= GPUCostK
 	p.Skills[lang] = s
 	p.GPUs++
-	return true
+	return nil
 }

--- a/app/domain/task/task.go
+++ b/app/domain/task/task.go
@@ -1,6 +1,9 @@
 package task
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type Type string
 
@@ -48,4 +51,45 @@ func (t *Task) RemainingSeconds(at time.Time) int64 {
 		return 0
 	}
 	return int64(d / time.Second)
+}
+
+// taskJSON 是序列化用的 surrogate struct，讓 unexported 欄位可以持久化。
+type taskJSON struct {
+	ID         string        `json:"id"`
+	Type       Type          `json:"type"`
+	Language   string        `json:"language"`
+	Duration   time.Duration `json:"duration"`
+	BaseReward int64         `json:"baseReward"`
+	StartedAt  time.Time     `json:"startedAt"`
+	DoneAt     time.Time     `json:"doneAt"`
+	Active     bool          `json:"active"`
+}
+
+func (t Task) MarshalJSON() ([]byte, error) {
+	return json.Marshal(taskJSON{
+		ID:         t.ID,
+		Type:       t.Type,
+		Language:   t.Language,
+		Duration:   t.Duration,
+		BaseReward: t.BaseReward,
+		StartedAt:  t.startedAt,
+		DoneAt:     t.doneAt,
+		Active:     t.active,
+	})
+}
+
+func (t *Task) UnmarshalJSON(data []byte) error {
+	var j taskJSON
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	t.ID = j.ID
+	t.Type = j.Type
+	t.Language = j.Language
+	t.Duration = j.Duration
+	t.BaseReward = j.BaseReward
+	t.startedAt = j.StartedAt
+	t.doneAt = j.DoneAt
+	t.active = j.Active
+	return nil
 }

--- a/app/usecase/dto/game/viewmodel.go
+++ b/app/usecase/dto/game/viewmodel.go
@@ -1,5 +1,15 @@
 package game
 
+// OfflineResultDto 是 domain.OfflineResult 的 DTO 表示，
+// 讓 Adapter 層不需直接 import domain/gametime。
+type OfflineResultDto struct {
+	GainedKnowledge int64  `json:"gainedKnowledge"`
+	GainedResearch  int64  `json:"gainedResearch"`
+	ClampedTo8h     bool   `json:"clampedTo8h"`
+	AnomalyDetected bool   `json:"anomalyDetected"`
+	Message         string `json:"message,omitempty"`
+}
+
 // ViewModelDto 為最小展示資料，用於 CLI/UI。
 type ViewModelDto struct {
 	Knowledge       int64

--- a/app/usecase/game/interactor.go
+++ b/app/usecase/game/interactor.go
@@ -45,14 +45,20 @@ func (uc *Interactor) Initialize() error {
 	return nil
 }
 
-func (uc *Interactor) ClaimOffline(now time.Time) (gametime.OfflineResult, error) {
+func (uc *Interactor) ClaimOffline(now time.Time) (dto.OfflineResultDto, error) {
 	res := uc.calc.Compute(&uc.p, uc.ts, now)
 	// 更新 timestamps 的關閉時間供下次計算
 	uc.ts.WallClockAtClose = now
 	if err := uc.repo.Save(uc.p, uc.ts); err != nil {
-		return res, err
+		return dto.OfflineResultDto{}, err
 	}
-	return res, nil
+	return dto.OfflineResultDto{
+		GainedKnowledge: res.GainedKnowledge,
+		GainedResearch:  res.GainedResearch,
+		ClampedTo8h:     res.ClampedTo8h,
+		AnomalyDetected: res.AnomalyDetected,
+		Message:         res.Message,
+	}, nil
 }
 
 func (uc *Interactor) GetViewModel() dto.ViewModelDto {
@@ -142,15 +148,11 @@ func (uc *Interactor) TryFinish(now time.Time) (finished bool, reward int64, err
 }
 
 // UpgradeKnowledge 升級等級，扣除研究。
-func (uc *Interactor) UpgradeKnowledge() (ok bool, err error) {
-	ok = uc.p.UpgradeKnowledge()
-	if !ok {
-		return false, nil
+func (uc *Interactor) UpgradeKnowledge() error {
+	if err := uc.p.UpgradeKnowledge(); err != nil {
+		return err
 	}
-	if err = uc.repo.Save(uc.p, uc.ts); err != nil {
-		return false, err
-	}
-	return true, nil
+	return uc.repo.Save(uc.p, uc.ts)
 }
 
 // SelectLanguage 設定目前操作的語言
@@ -160,25 +162,17 @@ func (uc *Interactor) SelectLanguage(lang string) error {
 }
 
 // BuyServer 購買伺服器主機（佔用 Knowledge，提供顯卡插槽）
-func (uc *Interactor) BuyServer() (bool, error) {
-	ok := uc.p.BuyServer()
-	if !ok {
-		return false, nil
+func (uc *Interactor) BuyServer() error {
+	if err := uc.p.BuyServer(); err != nil {
+		return err
 	}
-	if err := uc.repo.Save(uc.p, uc.ts); err != nil {
-		return false, err
-	}
-	return true, nil
+	return uc.repo.Save(uc.p, uc.ts)
 }
 
 // BuyGPU 購買顯卡（需有插槽，佔用 Knowledge，提升研究產率）
-func (uc *Interactor) BuyGPU() (bool, error) {
-	ok := uc.p.BuyGPU()
-	if !ok {
-		return false, nil
+func (uc *Interactor) BuyGPU() error {
+	if err := uc.p.BuyGPU(); err != nil {
+		return err
 	}
-	if err := uc.repo.Save(uc.p, uc.ts); err != nil {
-		return false, err
-	}
-	return true, nil
+	return uc.repo.Save(uc.p, uc.ts)
 }

--- a/app/usecase/port/in/game/game.go
+++ b/app/usecase/port/in/game/game.go
@@ -3,22 +3,21 @@ package game
 import (
 	"time"
 
-	"go-ddd-architecture/app/domain/gametime"
 	dto "go-ddd-architecture/app/usecase/dto/game"
 )
 
 // Usecase 定義 Game 的 Input Port。
 type Usecase interface {
 	Initialize() error
-	ClaimOffline(now time.Time) (gametime.OfflineResult, error)
+	ClaimOffline(now time.Time) (dto.OfflineResultDto, error)
 	GetViewModel() dto.ViewModelDto
 	StartPractice(now time.Time) error
 	StartTargeted(now time.Time) error
 	StartDeploy(now time.Time) error
 	StartResearch(now time.Time) error
 	TryFinish(now time.Time) (finished bool, reward int64, err error)
-	UpgradeKnowledge() (ok bool, err error)
+	UpgradeKnowledge() error
 	SelectLanguage(lang string) error
-	BuyServer() (bool, error)
-	BuyGPU() (bool, error)
+	BuyServer() error
+	BuyGPU() error
 }


### PR DESCRIPTION
## 背景

本 PR 針對先前 Code Review 發現的問題進行修正，涵蓋一個實際的資料遺失 bug 與三項 DDD/Clean Architecture 架構改善。

---

## 修改內容

### 🐛 Bug Fix — Task 序列化問題（資料遺失）

**`app/domain/task/task.go`**

`Task` 的三個 unexported fields（`startedAt`、`doneAt`、`active`）在 JSON 序列化時被完全忽略，導致重啟後進行中的任務狀態消失。

**修法**：加入 `MarshalJSON` / `UnmarshalJSON`，透過 surrogate struct `taskJSON` 做橋接，讓 domain struct 不需暴露 fields 也能完整持久化。

---

### ♻️ DDD 改善 1 — Domain Errors

**`app/domain/player/errors.go`（新增）**

定義具名 domain errors，讓業務規則違反可被明確傳達：
- `ErrTaskAlreadyActive` — 任務衝突
- `ErrInsufficientResearch` — 研究點不足
- `ErrInsufficientKnowledge` — 知識點不足
- `ErrNoSlotAvailable` — 無 GPU 插槽

**`app/domain/player/player.go`**

- `StartPractice/Targeted/Deploy/Research` 改回傳 `error`（原為靜默 `return`）
- `UpgradeKnowledge/BuyServer/BuyGPU` 改回傳 `error`（原為 `bool`）

---

### ♻️ DDD 改善 2 — `activeLang()` Helper（DRY）

**`app/domain/player/player.go`**

六個 method 各自重複相同的預設語言 guard clause，抽取成 `activeLang()`：
- 預設語言常數 `defaultLanguage = "go"` 集中定義
- 所有 Start/Buy/Upgrade 方法統一呼叫 `activeLang()`

---

### ♻️ DDD 改善 3 — DTO 隔離（`OfflineResultDto`）

**`app/usecase/dto/game/viewmodel.go`**

新增 `OfflineResultDto`，讓 Adapter 層不需直接 import `domain/gametime`。

**`app/usecase/port/in/game/game.go`**

`ClaimOffline` 改回傳 `dto.OfflineResultDto`，移除 `gametime` import。

**`app/adapter/in/httpserver/game/handler.go`**

- 移除 `domain/gametime` import
- 以 `errors.Is()` 將 domain errors 映射為語意明確的 HTTP 狀態碼：
  - `ErrTaskAlreadyActive` → `409 Conflict`
  - `ErrInsufficientResearch/Knowledge` → `400 Bad Request`
  - `ErrNoSlotAvailable` → `400 Bad Request`

---

## 測試

```
go build ./...  ✅
go test ./...   ✅ (2 packages tested, all pass)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)